### PR TITLE
fix: preserve goal.md when re-running fastflow on an existing ticket

### DIFF
--- a/cmd/fastflow/main.go
+++ b/cmd/fastflow/main.go
@@ -230,9 +230,10 @@ func init() {
 // resolveGoal determines the goal from various input sources in priority order:
 // 1. --goal flag (explicit)
 // 2. --goal-file flag (file-based)
-// 3. Piped stdin
-// 4. Interactive stdin prompt
-func resolveGoal() (string, error) {
+// 3. Existing goal.md in run directory
+// 4. Piped stdin
+// 5. Interactive stdin prompt
+func resolveGoal(runDir string) (string, error) {
 	// Priority 1: Explicit --goal flag
 	if flagGoal != "" {
 		return flagGoal, nil
@@ -243,14 +244,19 @@ func resolveGoal() (string, error) {
 		return readGoalFile(flagGoalFile)
 	}
 
-	// Priority 3: Check if stdin has piped data
+	// Priority 3: Existing goal.md in run directory
+	if existing := runner.ReadExistingGoal(runDir); existing != "" {
+		return existing, nil
+	}
+
+	// Priority 4: Check if stdin has piped data
 	stat, _ := os.Stdin.Stat()
 	if (stat.Mode() & os.ModeCharDevice) == 0 {
 		// Data is being piped in
 		return readPipedStdin()
 	}
 
-	// Priority 4: Interactive stdin prompt
+	// Priority 5: Interactive stdin prompt
 	return readInteractiveStdin()
 }
 
@@ -391,15 +397,6 @@ func runRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("%s %s", errColor("ERROR"), depResult.Error())
 	}
 
-	// Resolve goal from various input sources (unless workflow skips goal)
-	var goal string
-	if !workflow.SkipGoal {
-		goal, err = resolveGoal()
-		if err != nil {
-			return fmt.Errorf("%s Failed to get goal: %w", errColor("ERROR"), err)
-		}
-	}
-
 	// Get current working directory
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -450,13 +447,25 @@ func runRun(cmd *cobra.Command, args []string) error {
 		resumeMode = "false" // Fresh worktree, no need to check for state
 	}
 
+	// Compute run directory (needs workDir from worktree setup)
+	runDir := runner.GetRunDir(workDir, flagTicket)
+
+	// Resolve goal from various input sources (unless workflow skips goal)
+	var goal string
+	if !workflow.SkipGoal {
+		goal, err = resolveGoal(runDir)
+		if err != nil {
+			return fmt.Errorf("%s Failed to get goal: %w", errColor("ERROR"), err)
+		}
+	}
+
 	// Create run context
 	ctx := &runner.RunContext{
 		Goal:       goal,
 		Ticket:     flagTicket,
 		Workflow:   flagWorkflow,
 		WorkDir:    workDir,
-		RunDir:     runner.GetRunDir(workDir, flagTicket),
+		RunDir:     runDir,
 		RepoPath:   cwd,
 		BranchName: branchName,
 	}

--- a/internal/runner/goal_test.go
+++ b/internal/runner/goal_test.go
@@ -1,0 +1,183 @@
+package runner
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseGoalField(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "valid frontmatter with goal",
+			content: "---\nticket: T-1\ngoal: Fix the bug\ncreated: 2024-01-01\n---\n\n# Goal\n\nFix the bug\n",
+			want:    "Fix the bug",
+		},
+		{
+			name:    "empty goal field",
+			content: "---\nticket: T-1\ngoal: \ncreated: 2024-01-01\n---\n",
+			want:    "",
+		},
+		{
+			name:    "no frontmatter",
+			content: "# Goal\n\nFix the bug\n",
+			want:    "",
+		},
+		{
+			name:    "no goal field in frontmatter",
+			content: "---\nticket: T-1\ncreated: 2024-01-01\n---\n",
+			want:    "",
+		},
+		{
+			name:    "double-quoted goal value",
+			content: "---\ngoal: \"Fix the bug\"\n---\n",
+			want:    "Fix the bug",
+		},
+		{
+			name:    "single-quoted goal value",
+			content: "---\ngoal: 'Fix the bug'\n---\n",
+			want:    "Fix the bug",
+		},
+		{
+			name:    "unclosed frontmatter",
+			content: "---\ngoal: Fix the bug\n",
+			want:    "",
+		},
+		{
+			name:    "empty content",
+			content: "",
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseGoalField(tt.content)
+			if got != tt.want {
+				t.Errorf("parseGoalField() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReadExistingGoal(t *testing.T) {
+	t.Run("file exists with goal", func(t *testing.T) {
+		dir := t.TempDir()
+		goalPath := filepath.Join(dir, "goal.md")
+		os.WriteFile(goalPath, []byte("---\ngoal: Fix the bug\n---\n"), 0644)
+
+		got := ReadExistingGoal(dir)
+		if got != "Fix the bug" {
+			t.Errorf("ReadExistingGoal() = %q, want %q", got, "Fix the bug")
+		}
+	})
+
+	t.Run("file does not exist", func(t *testing.T) {
+		got := ReadExistingGoal(t.TempDir())
+		if got != "" {
+			t.Errorf("ReadExistingGoal() = %q, want empty", got)
+		}
+	})
+
+	t.Run("file exists with empty goal", func(t *testing.T) {
+		dir := t.TempDir()
+		goalPath := filepath.Join(dir, "goal.md")
+		os.WriteFile(goalPath, []byte("---\ngoal: \n---\n"), 0644)
+
+		got := ReadExistingGoal(dir)
+		if got != "" {
+			t.Errorf("ReadExistingGoal() = %q, want empty", got)
+		}
+	})
+}
+
+func TestWriteGoalFile_PreservesExisting(t *testing.T) {
+	r := &Runner{}
+
+	t.Run("creates new file when none exists", func(t *testing.T) {
+		dir := t.TempDir()
+		ctx := &RunContext{
+			Goal: "Fix the bug", Ticket: "T-1",
+			RunDir: dir, RepoPath: "/repo",
+			BranchName: "main", WorkDir: "/work",
+		}
+
+		if err := r.writeGoalFile(ctx); err != nil {
+			t.Fatalf("writeGoalFile() error: %v", err)
+		}
+
+		content, _ := os.ReadFile(filepath.Join(dir, "goal.md"))
+		if got := parseGoalField(string(content)); got != "Fix the bug" {
+			t.Errorf("goal field = %q, want %q", got, "Fix the bug")
+		}
+	})
+
+	t.Run("preserves existing file when goal matches", func(t *testing.T) {
+		dir := t.TempDir()
+		goalPath := filepath.Join(dir, "goal.md")
+		original := "---\nticket: T-1\ngoal: Fix the bug\ncreated: 2024-01-01T00:00:00Z\n---\n\n# Goal\n\nFix the bug\n\n# Context\n\nCustom user-edited context\n"
+		os.WriteFile(goalPath, []byte(original), 0644)
+
+		ctx := &RunContext{
+			Goal: "Fix the bug", Ticket: "T-1",
+			RunDir: dir, RepoPath: "/repo",
+			BranchName: "main", WorkDir: "/work",
+		}
+
+		if err := r.writeGoalFile(ctx); err != nil {
+			t.Fatalf("writeGoalFile() error: %v", err)
+		}
+
+		after, _ := os.ReadFile(goalPath)
+		if string(after) != original {
+			t.Error("existing file was modified when goal matched")
+		}
+	})
+
+	t.Run("overwrites when goal changes", func(t *testing.T) {
+		dir := t.TempDir()
+		goalPath := filepath.Join(dir, "goal.md")
+		os.WriteFile(goalPath, []byte("---\ngoal: Old goal\n---\n"), 0644)
+
+		ctx := &RunContext{
+			Goal: "New goal", Ticket: "T-1",
+			RunDir: dir, RepoPath: "/repo",
+			BranchName: "main", WorkDir: "/work",
+		}
+
+		if err := r.writeGoalFile(ctx); err != nil {
+			t.Fatalf("writeGoalFile() error: %v", err)
+		}
+
+		after, _ := os.ReadFile(goalPath)
+		if got := parseGoalField(string(after)); got != "New goal" {
+			t.Errorf("goal field = %q, want %q", got, "New goal")
+		}
+	})
+
+	t.Run("overwrites when existing goal is empty", func(t *testing.T) {
+		dir := t.TempDir()
+		goalPath := filepath.Join(dir, "goal.md")
+		os.WriteFile(goalPath, []byte("---\ngoal: \n---\n"), 0644)
+
+		ctx := &RunContext{
+			Goal: "New goal", Ticket: "T-1",
+			RunDir: dir, RepoPath: "/repo",
+			BranchName: "main", WorkDir: "/work",
+		}
+
+		if err := r.writeGoalFile(ctx); err != nil {
+			t.Fatalf("writeGoalFile() error: %v", err)
+		}
+
+		after, _ := os.ReadFile(goalPath)
+		if !strings.Contains(string(after), "goal: New goal") {
+			t.Error("expected goal.md to be written with new goal")
+		}
+	})
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -101,7 +101,7 @@ func (r *Runner) Run(ctx *RunContext) error {
 		pipelineState = state.NewState(ctx.Workflow, workflow.Stages)
 	}
 
-	// Write the goal file (always, to ensure it's current)
+	// Write the goal file (preserves existing if goal unchanged)
 	if err := r.writeGoalFile(ctx); err != nil {
 		return fmt.Errorf("failed to write goal file: %w", err)
 	}
@@ -504,9 +504,18 @@ func (r *Runner) handleCheckpoint(ctx *RunContext, stageName string) error {
 	return nil
 }
 
-// writeGoalFile creates the initial goal.md file in the run directory.
+// writeGoalFile creates or updates the goal.md file in the run directory.
+// If goal.md already exists with a non-empty goal that matches ctx.Goal,
+// the file is preserved to retain any user-edited content.
 func (r *Runner) writeGoalFile(ctx *RunContext) error {
 	goalPath := filepath.Join(ctx.RunDir, "goal.md")
+
+	// If goal.md already exists with a matching non-empty goal, preserve it.
+	if existing, err := os.ReadFile(goalPath); err == nil {
+		if existingGoal := parseGoalField(string(existing)); existingGoal != "" && ctx.Goal == existingGoal {
+			return nil
+		}
+	}
 
 	content := fmt.Sprintf(`---
 ticket: %s
@@ -528,6 +537,47 @@ Run Directory: %s
 		ctx.Goal, filepath.Base(ctx.RepoPath), ctx.BranchName, ctx.WorkDir, ctx.RunDir)
 
 	return os.WriteFile(goalPath, []byte(content), 0644)
+}
+
+// ReadExistingGoal reads the goal from an existing goal.md in the given directory.
+// Returns an empty string if the file doesn't exist or has no goal.
+func ReadExistingGoal(runDir string) string {
+	goalPath := filepath.Join(runDir, "goal.md")
+	content, err := os.ReadFile(goalPath)
+	if err != nil {
+		return ""
+	}
+	return parseGoalField(string(content))
+}
+
+// parseGoalField extracts the goal: value from goal.md frontmatter content.
+// Returns empty string if content has no frontmatter or no non-empty goal field.
+func parseGoalField(content string) string {
+	if !strings.HasPrefix(content, "---") {
+		return ""
+	}
+
+	lines := strings.Split(content, "\n")
+	endIdx := -1
+	for i := 1; i < len(lines); i++ {
+		if lines[i] == "---" {
+			endIdx = i
+			break
+		}
+	}
+	if endIdx == -1 {
+		return ""
+	}
+
+	for i := 1; i < endIdx; i++ {
+		line := strings.TrimSpace(lines[i])
+		if strings.HasPrefix(line, "goal:") {
+			value := strings.TrimSpace(strings.TrimPrefix(line, "goal:"))
+			return strings.Trim(value, "\"'")
+		}
+	}
+
+	return ""
 }
 
 // SetupWorktreeOpts configures worktree creation behavior.


### PR DESCRIPTION
## Problem

Every `fastflow run` invocation overwrites `thoughts/shared/runs/{ticket}/goal.md` with a fresh template, destroying any user-edited content (custom context, notes, etc.). Users were forced to re-supply `--goal` or `--goal-file` on every run to avoid losing their work.

Fixes #12.

## Solution

Three-part fix:

**1. `writeGoalFile` preserves existing files** (`internal/runner/runner.go`)

Before writing, the function reads any existing `goal.md`. If the file exists and its `goal:` frontmatter field matches the current goal, the file is left untouched. Only when the goal has changed (or the file is new/empty) is it written.

**2. `resolveGoal` reads from existing goal.md** (`cmd/fastflow/main.go`)

A new priority level is inserted between `--goal-file` and stdin: if a `goal.md` already exists in the run directory with a non-empty goal, that value is used automatically. This means re-running `fastflow run --ticket X` on an existing ticket Just Works™ — no flags needed.

The function signature gains a `runDir string` parameter; the run directory is now computed right after worktree setup (before goal resolution) so it can be threaded in.

**3. New helpers with full test coverage** (`internal/runner/runner.go`, `internal/runner/goal_test.go`)

- `ReadExistingGoal(runDir string) string` — exported helper used by `main.go`
- `parseGoalField(content string) string` — parses the `goal:` value from YAML frontmatter

## Behavior after this change

| Scenario | Before | After |
|---|---|---|
| Re-run with same goal | goal.md overwritten | goal.md preserved |
| Re-run with new goal | goal.md overwritten | goal.md updated |
| First run, no goal.md | goal.md created | goal.md created (unchanged) |
| `--goal-file` provided | content passed as goal only | content written into goal.md too |
| `--goal` provided | explicit goal used | explicit goal used (unchanged) |

## How to verify

```bash
# Build
go build ./...

# Run tests
go test ./internal/runner/...

# Manual smoke test
fastflow run --ticket TEST          # creates goal.md
# Edit thoughts/shared/runs/TEST/goal.md — add some custom notes
fastflow run --ticket TEST          # goal.md should be unchanged
```