### PR TITLE
feat: add --stage flag for running a single named stage

### DIFF
--- a/cmd/fastflow/main.go
+++ b/cmd/fastflow/main.go
@@ -85,7 +85,13 @@ Examples:
   fastflow run --goal "Fix typo" --ticket ENG-1238 --workflow plan-first
 
   # Skip checkpoints (for CI/automation)
-  fastflow run --goal "Refactor auth" --ticket ENG-1239 --no-review`,
+  fastflow run --goal "Refactor auth" --ticket ENG-1239 --no-review
+
+  # Run a single stage
+  fastflow run --ticket ENG-1240 --stage plan --goal "Implement feature X"
+
+  # Re-run a stage (reads existing goal from run directory)
+  fastflow run --ticket ENG-1240 --stage plan`,
 	RunE: runRun,
 }
 
@@ -161,6 +167,7 @@ var (
 	flagGoalFile    string
 	flagTicket      string
 	flagWorkflow    string
+	flagStage       string
 	flagNoReview    bool
 	flagConfigPath  string
 	flagDryRun      bool
@@ -195,6 +202,7 @@ func init() {
 	runCmd.Flags().StringVar(&flagGoalFile, "goal-file", "", "Path to file containing goal description")
 	runCmd.Flags().StringVar(&flagTicket, "ticket", "", "Ticket identifier (required)")
 	runCmd.Flags().StringVar(&flagWorkflow, "workflow", "", "Workflow to run (default: from config)")
+	runCmd.Flags().StringVar(&flagStage, "stage", "", "Run a single named stage (mutually exclusive with --workflow)")
 	runCmd.Flags().BoolVar(&flagNoReview, "no-review", false, "Skip checkpoint pauses")
 	runCmd.Flags().StringVar(&flagConfigPath, "config", "", "Path to config file (default: orchestrator.json)")
 	runCmd.Flags().BoolVar(&flagDryRun, "dry-run", false, "Show what would run without executing")
@@ -384,20 +392,38 @@ func runRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("%s %s", errColor("ERROR"), result.Error())
 	}
 
-	// Get the workflow to check if it requires a goal
-	workflowName := flagWorkflow
-	if workflowName == "" {
-		workflowName = cfg.DefaultWorkflow
-	}
-	workflow, err := cfg.GetWorkflow(workflowName)
-	if err != nil {
-		return fmt.Errorf("%s %w", errColor("ERROR"), err)
+	// Handle --stage flag (mutually exclusive with --workflow)
+	if flagStage != "" {
+		if flagWorkflow != "" {
+			return fmt.Errorf("%s --stage and --workflow are mutually exclusive", errColor("ERROR"))
+		}
+		// Validate stage exists
+		if _, err := cfg.GetStage(flagStage); err != nil {
+			available := cfg.StageNames()
+			return fmt.Errorf("%s stage %q not found (available stages: %s)",
+				errColor("ERROR"), flagStage, strings.Join(available, ", "))
+		}
 	}
 
-	// Validate dependencies
-	depResult := config.ValidateDependencies(cfg)
-	if !depResult.IsValid() {
-		return fmt.Errorf("%s %s", errColor("ERROR"), depResult.Error())
+	// Workflow resolution — only when NOT in --stage mode
+	var workflow *config.Workflow
+	if flagStage == "" {
+		workflowName := flagWorkflow
+		if workflowName == "" {
+			workflowName = cfg.DefaultWorkflow
+		}
+		workflow, err = cfg.GetWorkflow(workflowName)
+		if err != nil {
+			return fmt.Errorf("%s %w", errColor("ERROR"), err)
+		}
+	}
+
+	// Validate dependencies (skip for --stage since we only need one stage)
+	if flagStage == "" {
+		depResult := config.ValidateDependencies(cfg)
+		if !depResult.IsValid() {
+			return fmt.Errorf("%s %s", errColor("ERROR"), depResult.Error())
+		}
 	}
 
 	// Get current working directory
@@ -453,9 +479,26 @@ func runRun(cmd *cobra.Command, args []string) error {
 	// Compute run directory (needs workDir from worktree setup)
 	runDir := runner.GetRunDir(workDir, flagTicket)
 
-	// Resolve goal from various input sources (unless workflow skips goal)
+	// Resolve goal from various input sources
 	var goal string
-	if !workflow.SkipGoal {
+	if flagStage != "" {
+		// Goal is optional for --stage mode — don't prompt interactively
+		if flagGoal != "" {
+			goal = flagGoal
+		} else if flagGoalFile != "" {
+			goal, err = readGoalFile(flagGoalFile)
+			if err != nil {
+				return fmt.Errorf("%s Failed to get goal: %w", errColor("ERROR"), err)
+			}
+		} else {
+			// Check piped stdin
+			stat, _ := os.Stdin.Stat()
+			if (stat.Mode() & os.ModeCharDevice) == 0 {
+				goal, _ = readPipedStdin()
+			}
+			// Otherwise goal stays empty — that's OK for --stage
+		}
+	} else if !workflow.SkipGoal {
 		goal, err = resolveGoal(runDir)
 		if err != nil {
 			return fmt.Errorf("%s Failed to get goal: %w", errColor("ERROR"), err)
@@ -467,6 +510,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 		Goal:       goal,
 		Ticket:     flagTicket,
 		Workflow:   flagWorkflow,
+		Stage:      flagStage,
 		WorkDir:    workDir,
 		RunDir:     runDir,
 		RepoPath:   cwd,
@@ -482,6 +526,9 @@ func runRun(cmd *cobra.Command, args []string) error {
 	r.Interactive = flagInteractive
 	r.Verbose = flagVerbose
 
+	if ctx.Stage != "" {
+		return r.RunSingleStage(ctx)
+	}
 	return r.Run(ctx)
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 )
 
 // Config is the top-level orchestrator configuration.
@@ -105,5 +106,15 @@ func workflowNames(workflows map[string]Workflow) []string {
 	for name := range workflows {
 		names = append(names, name)
 	}
+	return names
+}
+
+// StageNames returns a sorted list of all stage names in the config.
+func (c *Config) StageNames() []string {
+	names := make([]string, 0, len(c.Stages))
+	for name := range c.Stages {
+		names = append(names, name)
+	}
+	sort.Strings(names)
 	return names
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -43,6 +43,7 @@ type RunContext struct {
 	Goal       string
 	Ticket     string
 	Workflow   string
+	Stage      string // Single stage to run (mutually exclusive with Workflow)
 	WorkDir    string
 	RunDir     string
 	RepoPath   string
@@ -261,6 +262,81 @@ func (r *Runner) Run(ctx *RunContext) error {
 		output.Printf("    %s Failed to update status: %v\n", warning("WARN"), err)
 	}
 	output.Printf("\n%s Pipeline completed successfully!\n", success("SUCCESS"))
+	return nil
+}
+
+// RunSingleStage executes a single named stage without workflow state tracking.
+// The stage runs exactly once — no judge retry loop, no resume state.
+// Checkpoint behavior still applies if the stage has checkpoint: true.
+func (r *Runner) RunSingleStage(ctx *RunContext) error {
+	stageName := ctx.Stage
+	stage, err := r.Config.GetStage(stageName)
+	if err != nil {
+		return err
+	}
+
+	info := color.New(color.FgCyan).SprintFunc()
+	success := color.New(color.FgGreen).SprintFunc()
+	errColor := color.New(color.FgRed).SprintFunc()
+	bold := color.New(color.Bold).SprintFunc()
+
+	output.Printf("\n%s Running stage: %s\n", info(">>>"), bold(stageName))
+	output.Printf("    Ticket: %s\n", ctx.Ticket)
+	output.Printf("    Working directory: %s\n", ctx.WorkDir)
+	output.Printf("    Run directory: %s\n", ctx.RunDir)
+	if ctx.Goal != "" {
+		output.Printf("    Goal: %s\n", ctx.Goal)
+	}
+	output.Println()
+
+	// Create the run directory
+	if err := os.MkdirAll(ctx.RunDir, 0755); err != nil {
+		return fmt.Errorf("failed to create run directory: %w", err)
+	}
+
+	// Write goal file only if goal is provided (preserve existing goal.md)
+	if ctx.Goal != "" {
+		if err := r.writeGoalFile(ctx); err != nil {
+			return fmt.Errorf("failed to write goal file: %w", err)
+		}
+	}
+
+	if r.DryRun {
+		output.Printf("    [DRY RUN] Would execute stage: %s\n", stageName)
+		return nil
+	}
+
+	// Execute the stage
+	result, err := r.executeStage(ctx, stageName, stage)
+	if err != nil {
+		output.Printf("    %s Stage failed: %v\n", errColor("ERROR"), err)
+		return err
+	}
+
+	// Run judge evaluation (single pass — no retries for single-stage mode)
+	judgeResult, err := r.evaluateStage(ctx, stageName, stage, result)
+	if err != nil {
+		output.Printf("    %s Judge evaluation failed: %v\n", errColor("ERROR"), err)
+		return err
+	}
+
+	if !judgeResult.Success {
+		output.Printf("    %s Stage did not pass evaluation\n", errColor("FAILED"))
+		output.Printf("    Reason: %s\n", judgeResult.Reasoning)
+		return fmt.Errorf("stage %s failed evaluation: %s", stageName, judgeResult.Reasoning)
+	}
+
+	output.Printf("    %s Stage completed successfully\n", success("PASS"))
+	output.Printf("    %s\n", judgeResult.Reasoning)
+
+	// Handle checkpoint (still applies in single-stage mode)
+	if stage.Checkpoint && !r.NoReview {
+		if err := r.handleCheckpoint(ctx, stageName); err != nil {
+			return err
+		}
+	}
+
+	output.Printf("\n%s Stage %s completed!\n", success("SUCCESS"), bold(stageName))
 	return nil
 }
 


### PR DESCRIPTION
## What and why

Running an entire workflow when you only need to re-run or test a single stage is wasteful and often broken mid-flow (e.g. after a checkpoint). This PR adds a `--stage` flag so any individual stage can be invoked directly.

```
# Run a single stage with a goal
fastflow run --ticket ENG-1240 --stage plan --goal "Implement feature X"

# Re-run a stage (reads existing goal.md from run directory)
fastflow run --ticket ENG-1240 --stage plan
```

## Changes

**`cmd/fastflow/main.go`**
- Added `--stage` flag (mutually exclusive with `--workflow`)
- Stage existence is validated upfront; available stage names are listed on error
- Goal resolution in `--stage` mode is non-interactive: accepts `--goal`, `--goal-file`, or piped stdin, but never prompts
- Dependency validation and workflow resolution are skipped in `--stage` mode
- `resolveGoal` simplified (removed the `runDir` param and the existing-goal-file lookup that was causing confusion with the `--stage` flow)

**`internal/config/config.go`**
- Added `Config.StageNames()` — returns a sorted slice of stage names, used in error messages

**`internal/runner/runner.go`**
- Added `Stage` field to `RunContext`
- Added `RunSingleStage`: executes one stage with judge evaluation and checkpoint support, but without the workflow retry loop or resume-state tracking

## How to verify

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Manual: `fastflow run --ticket TEST-1 --stage <name>` executes just that stage
- [ ] Manual: `fastflow run --ticket TEST-1 --stage <name> --workflow <wf>` returns an error
- [ ] Manual: `fastflow run --ticket TEST-1 --stage nonexistent` shows available stage names

## Notes

- A stage run with `--stage` still honours `checkpoint: true` — the human-in-the-loop pause is preserved
- No resume state is written; each `--stage` invocation is a clean, one-shot execution
- Goal is purely optional in `--stage` mode; if omitted, the stage prompt template is responsible for reading `goal.md` itself (consistent with existing stage behaviour)