### PR TITLE
fix(ci): use pull_request_target to allow tag push from fork PRs

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -1,7 +1,7 @@
 name: Release on PR Merge
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
     branches:


### PR DESCRIPTION
## What and why

After PR #20 fixed the heredoc/backtick issue, the release workflow hit a second failure: `fatal: unable to access '...': The requested URL returned error: 403` when trying to push a release tag.

**Root cause:** `pull_request` events from forks run with a read-only `GITHUB_TOKEN` — GitHub enforces this as a security measure. Even though the workflow declares `permissions: contents: write`, those permissions are downgraded to read-only for fork PRs.

**Fix:** Change the trigger from `pull_request` to `pull_request_target`. The `pull_request_target` event runs the workflow in the context of the *base* repository (not the fork), so the `GITHUB_TOKEN` retains write access to push tags and create releases.

## How to verify

Merge any PR from a fork — the release workflow should successfully push a tag and create a GitHub Release.