### PR TITLE
fix: treat non-zero exit codes as failures when Claude produces no usable output

### DIFF
--- a/internal/runner/claude.go
+++ b/internal/runner/claude.go
@@ -103,6 +103,16 @@ func (c *ClaudeInvoker) invokeWithEnv(prompt string, model string, env []string)
 		if isNotLoggedIn(result.RawOutput) {
 			return nil, ErrNotLoggedIn
 		}
+		if isRateLimited(result.RawOutput) {
+			return nil, ErrRateLimited
+		}
+		if result.ExitCode != 0 && result.Output == "" {
+			snippet := strings.TrimSpace(result.RawOutput)
+			if len(snippet) > 300 {
+				snippet = snippet[len(snippet)-300:]
+			}
+			return nil, fmt.Errorf("claude exited with code %d: %s", result.ExitCode, snippet)
+		}
 		result.HitMaxTurns = isMaxTurnsError(result.Output)
 		if c.Debug && result.HitMaxTurns {
 			output.Printf("[DEBUG] Max turns limit detected in output\n")
@@ -144,6 +154,20 @@ func (c *ClaudeInvoker) invokeWithEnv(prompt string, model string, env []string)
 		return nil, ErrNotLoggedIn
 	}
 
+	// Detect rate limit
+	if isRateLimited(result.RawOutput) {
+		return nil, ErrRateLimited
+	}
+
+	// Treat non-zero exit with no usable output as a failure
+	if result.ExitCode != 0 && result.Output == "" {
+		snippet := strings.TrimSpace(result.RawOutput)
+		if len(snippet) > 300 {
+			snippet = snippet[len(snippet)-300:]
+		}
+		return nil, fmt.Errorf("claude exited with code %d: %s", result.ExitCode, snippet)
+	}
+
 	// Detect if max-turns was hit
 	result.HitMaxTurns = isMaxTurnsError(result.Output)
 	if c.Debug && result.HitMaxTurns {
@@ -166,6 +190,16 @@ var ErrNotLoggedIn = fmt.Errorf("claude is not logged in: please run 'claude' in
 func isNotLoggedIn(output string) bool {
 	return strings.Contains(output, "Not logged in") ||
 		strings.Contains(output, "Please run /login")
+}
+
+// ErrRateLimited is returned when Claude CLI reports a rate limit was hit.
+var ErrRateLimited = fmt.Errorf("claude rate limit reached: please wait before retrying")
+
+// isRateLimited checks if the output indicates a rate limit was hit.
+func isRateLimited(out string) bool {
+	lower := strings.ToLower(out)
+	return strings.Contains(lower, "you've hit your limit") ||
+		strings.Contains(lower, "rate limit")
 }
 
 // ErrInvalidAPIKey is returned when the API key is set but rejected by the API.

--- a/internal/runner/claude_test.go
+++ b/internal/runner/claude_test.go
@@ -45,6 +45,35 @@ func TestIsNotLoggedIn(t *testing.T) {
 	}
 }
 
+func TestIsRateLimited(t *testing.T) {
+	if !isRateLimited("You've hit your limit for today") {
+		t.Error("should detect \"You've hit your limit\"")
+	}
+	if !isRateLimited("rate limit exceeded, please slow down") {
+		t.Error("should detect \"rate limit\"")
+	}
+	// Case-insensitive
+	if !isRateLimited("Rate Limit Exceeded") {
+		t.Error("should detect \"Rate Limit\" case-insensitively")
+	}
+	// Should NOT trigger on normal output
+	if isRateLimited("Hello, I'm Claude. How can I help you?") {
+		t.Error("should not trigger on normal output")
+	}
+}
+
+func TestIsMaxTurnsError(t *testing.T) {
+	if !isMaxTurnsError("Reached max turns") {
+		t.Error("should detect \"Reached max turns\"")
+	}
+	if !isMaxTurnsError("Error: Reached max turns (50)") {
+		t.Error("should detect \"Error: Reached max turns\"")
+	}
+	if isMaxTurnsError("Task completed successfully") {
+		t.Error("should not trigger on normal output")
+	}
+}
+
 func TestEnvWithoutAPIKey(t *testing.T) {
 	// Set a test API key
 	os.Setenv("ANTHROPIC_API_KEY", "test-key")


### PR DESCRIPTION
## Problem

`fastflow list` was showing failed Claude Code runs as `active` because `Invoke()` in `internal/runner/claude.go` captured non-zero exit codes in `result.ExitCode` but always returned `(result, nil)`. Since the runner only calls `SetStatus(failed)` when `executeStage` returns an error, failures were silently swallowed.

Fixes #23

## Changes

**`internal/runner/claude.go`**
- Add `ErrRateLimited` sentinel error and `isRateLimited()` helper that detects "you've hit your limit" / "rate limit" patterns in Claude output (mirrors existing `isNotLoggedIn()`)
- After auth-failure detection, check for rate limiting and return `ErrRateLimited` when detected
- If Claude exits with a non-zero code **and** produced no usable output (`result.Output == ""`), return an error containing the exit code and a tail of `RawOutput` for context. Runs that exit non-zero but still produced a valid result stream are left unaffected (key constraint from the issue)

**`internal/runner/claude_test.go`**
- Add `TestIsRateLimited` covering positive cases (case-insensitive) and a negative case
- Add `TestIsMaxTurnsError` covering positive and negative cases

## How to verify

- [x] `go test ./internal/runner/...` — all tests pass, including the new `TestIsRateLimited` and `TestIsMaxTurnsError`