### PR TITLE
feat: add fastflow monitor web dashboard (REL-394)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,33 @@ fastflow run --goal "Refactor auth system" --ticket ENG-1237 --no-review
 fastflow validate
 ```
 
+### Monitor
+
+Start a web dashboard for monitoring in-flight fastflow runs:
+
+```bash
+fastflow monitor
+```
+
+Open `http://localhost:8080` in a browser to view the dashboard. The dashboard shows all active and recent runs with their ticket, status, current stage, timestamps, PID (if live), and log file path. It auto-refreshes every 5 seconds.
+
+Options:
+- `--addr` — Address to listen on (default: `:8080`)
+
+```bash
+# Use a custom address
+fastflow monitor --addr :9090
+```
+
+#### API
+
+The monitor also exposes a JSON API:
+
+- `GET /api/runs` — Returns all runs as a JSON array
+- `GET /api/runs?prefix=ENG-` — Filter runs by ticket prefix
+
+Each entry includes: `ticket`, `status`, `stage`, `created`, `updated_at`, `pid`, `log_path`, `work_dir`, `run_dir`.
+
 ## Configuration
 
 fastflow uses `orchestrator.json` for workflow configuration. See the included config for examples of:

--- a/cmd/fastflow/main.go
+++ b/cmd/fastflow/main.go
@@ -14,6 +14,7 @@ import (
 	"syscall"
 
 	"github.com/redblacktree/fastflow/internal/config"
+	"github.com/redblacktree/fastflow/internal/monitor"
 	"github.com/redblacktree/fastflow/internal/output"
 	"github.com/redblacktree/fastflow/internal/runner"
 	"github.com/redblacktree/fastflow/internal/state"
@@ -149,6 +150,25 @@ Examples:
 	RunE: runList,
 }
 
+var monitorCmd = &cobra.Command{
+	Use:   "monitor",
+	Short: "Start a web dashboard for monitoring fastflow runs",
+	Long: `Start a lightweight, read-only web dashboard for monitoring in-flight fastflow runs.
+
+The dashboard shows all active and recent runs across worktrees with their status,
+current stage, timestamps, PID (if live), and log file path.
+
+A JSON API is also available at /api/runs for programmatic access.
+
+Examples:
+  # Start monitor on default port 8080
+  fastflow monitor
+
+  # Start on a custom address
+  fastflow monitor --addr :9090`,
+	RunE: runMonitor,
+}
+
 var cleanCmd = &cobra.Command{
 	Use:   "clean [ticket]",
 	Short: "Remove worktrees",
@@ -191,6 +211,7 @@ var (
 	flagRunForce     bool
 	flagOnComplete   string
 	flagBackground   bool
+	flagMonitorAddr  string
 )
 
 func init() {
@@ -241,12 +262,16 @@ func init() {
 	cleanCmd.Flags().StringVar(&flagCleanPrefix, "prefix", "", "Clean all worktrees matching prefix")
 	cleanCmd.Flags().BoolVar(&flagCleanForce, "force", false, "Skip confirmation prompt")
 
+	// Monitor command flags
+	monitorCmd.Flags().StringVar(&flagMonitorAddr, "addr", ":8080", "Address to listen on")
+
 	// Add commands
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(validateCmd)
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(cleanCmd)
+	rootCmd.AddCommand(monitorCmd)
 }
 
 // resolveGoal determines the goal from various input sources in priority order:
@@ -788,174 +813,28 @@ func findExecutable(name string, args ...string) (string, error) {
 	return "", fmt.Errorf("command not found: %s", name)
 }
 
+func runMonitor(cmd *cobra.Command, args []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get working directory: %w", err)
+	}
+	fmt.Printf("Starting fastflow monitor at http://localhost%s\n", flagMonitorAddr)
+	srv := &monitor.Server{Addr: flagMonitorAddr, CWD: cwd}
+	return srv.Start()
+}
+
 func runList(cmd *cobra.Command, args []string) error {
 	bold := color.New(color.Bold).SprintFunc()
 	dim := color.New(color.Faint).SprintFunc()
 
-	// Get current working directory
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get working directory: %w", err)
 	}
 
-	// --- Source 1: Worktree-based runs ---
-	type listEntry struct {
-		Ticket  string
-		Status  string
-		Stage   string
-		Created string
-		Summary string
-		Pid     int
-		LogPath string
-	}
-
-	seen := make(map[string]bool)
-	var entries []listEntry
-
-	mgr, err := worktree.NewManager(cwd)
-	if err == nil {
-		worktrees, err := mgr.List()
-		if err == nil {
-			for _, wt := range worktrees {
-				status := "active"
-				if wt.IsOrphan {
-					status = "orphaned"
-				}
-
-				created := ""
-				summary := dim("(no goal file)")
-				stage := ""
-
-				// Try to read ticket info from goal.md
-				for _, loc := range []string{wt.Path, cwd} {
-					if info := worktree.ReadTicketInfo(loc, wt.Ticket); info != nil {
-						if info.Created != "" {
-							created = info.Created
-							if len(created) > 19 {
-								created = created[:19]
-							}
-							created = strings.Replace(created, "T", " ", 1)
-						}
-						if info.Goal != "" {
-							summary = info.Goal
-							if len(summary) > 40 {
-								summary = summary[:37] + "..."
-							}
-						}
-						break
-					}
-				}
-
-				// Try to read state.json for richer status
-				runDir := runner.GetRunDir(wt.Path, wt.Ticket)
-				var entryPid int
-				if st, loadErr := state.Load(runDir); loadErr == nil && st != nil && st.Status != "" {
-					status = st.Status
-					stage = st.Stage
-					// Detect stale runs: status is running but process is dead
-					if status == state.StatusRunning {
-						pid, _ := state.ReadPID(runDir)
-						if pid > 0 {
-							if !state.IsProcessAlive(pid) {
-								status = "stale"
-							} else {
-								entryPid = pid
-							}
-						}
-					}
-				}
-
-				var entryLogPath string
-				logPath := filepath.Join(runDir, "fastflow.log")
-				if _, statErr := os.Stat(logPath); statErr == nil {
-					entryLogPath = logPath
-				}
-
-				entries = append(entries, listEntry{
-					Ticket:  wt.Ticket,
-					Status:  status,
-					Stage:   stage,
-					Created: created,
-					Summary: summary,
-					Pid:     entryPid,
-					LogPath: entryLogPath,
-				})
-				seen[wt.Ticket] = true
-			}
-		}
-	}
-
-	// --- Source 2: State-based runs (non-worktree) from current repo ---
-	stateRuns, _ := state.ScanRunDirs(cwd)
-	for _, run := range stateRuns {
-		if seen[run.Ticket] {
-			continue // Already listed via worktree
-		}
-
-		status := run.State.Status
-		if status == "" {
-			status = "unknown"
-		}
-		// Detect stale runs: status is running but process is dead
-		var entryPid int
-		if status == state.StatusRunning {
-			pid, _ := state.ReadPID(run.RunDir)
-			if pid > 0 {
-				if !state.IsProcessAlive(pid) {
-					status = "stale"
-				} else {
-					entryPid = pid
-				}
-			}
-		}
-		stage := run.State.Stage
-		created := ""
-		summary := dim("(no goal file)")
-
-		// Read goal info
-		if info := worktree.ReadTicketInfo(cwd, run.Ticket); info != nil {
-			if info.Created != "" {
-				created = info.Created
-				if len(created) > 19 {
-					created = created[:19]
-				}
-				created = strings.Replace(created, "T", " ", 1)
-			}
-			if info.Goal != "" {
-				summary = info.Goal
-				if len(summary) > 40 {
-					summary = summary[:37] + "..."
-				}
-			}
-		}
-
-		var entryLogPath string
-		logPath := filepath.Join(run.RunDir, "fastflow.log")
-		if _, statErr := os.Stat(logPath); statErr == nil {
-			entryLogPath = logPath
-		}
-
-		entries = append(entries, listEntry{
-			Ticket:  run.Ticket,
-			Status:  status,
-			Stage:   stage,
-			Created: created,
-			Summary: summary,
-			Pid:     entryPid,
-			LogPath: entryLogPath,
-		})
-		seen[run.Ticket] = true
-	}
-
-	// Filter by prefix if specified
-	if flagListPrefix != "" {
-		var filtered []listEntry
-		for _, e := range entries {
-			if strings.HasPrefix(e.Ticket, flagListPrefix) {
-				filtered = append(filtered, e)
-			}
-		}
-		entries = filtered
+	entries, err := monitor.DiscoverRuns(cwd, flagListPrefix)
+	if err != nil {
+		return fmt.Errorf("failed to discover runs: %w", err)
 	}
 
 	if len(entries) == 0 {
@@ -998,8 +877,15 @@ func runList(cmd *cobra.Command, args []string) error {
 		if e.Pid > 0 {
 			pidStr = fmt.Sprintf(" (pid %d)", e.Pid)
 		}
+		summary := e.Summary
+		if len(summary) > 40 {
+			summary = summary[:37] + "..."
+		}
+		if summary == "(no goal file)" {
+			summary = dim(summary)
+		}
 		output.Printf("%-12s  %-12s  %-12s  %-20s  %s%s\n",
-			e.Ticket, statusFmt, e.Stage, e.Created, e.Summary, pidStr)
+			e.Ticket, statusFmt, e.Stage, e.Created, summary, pidStr)
 		if e.LogPath != "" {
 			output.Printf("%-12s  %s\n", "", dim("Log: "+e.LogPath))
 		}

--- a/internal/monitor/dashboard.go
+++ b/internal/monitor/dashboard.go
@@ -1,0 +1,6 @@
+package monitor
+
+import _ "embed"
+
+//go:embed dashboard.html
+var dashboardHTML string

--- a/internal/monitor/dashboard.html
+++ b/internal/monitor/dashboard.html
@@ -1,0 +1,300 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fastflow Monitor</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+      font-size: 13px;
+      background: #0f1117;
+      color: #e2e8f0;
+      min-height: 100vh;
+    }
+
+    header {
+      background: #1a1f2e;
+      border-bottom: 1px solid #2d3748;
+      padding: 12px 24px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    header h1 {
+      font-size: 16px;
+      font-weight: 600;
+      color: #e2e8f0;
+      letter-spacing: 0.05em;
+    }
+
+    header h1 span {
+      color: #63b3ed;
+    }
+
+    .refresh-indicator {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      color: #718096;
+      font-size: 12px;
+    }
+
+    .pulse-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: #48bb78;
+      animation: pulse 2s ease-in-out infinite;
+    }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.3; }
+    }
+
+    .stats-bar {
+      background: #161b27;
+      border-bottom: 1px solid #2d3748;
+      padding: 10px 24px;
+      display: flex;
+      gap: 24px;
+    }
+
+    .stat {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      color: #718096;
+      font-size: 12px;
+    }
+
+    .stat-value {
+      font-weight: 600;
+      color: #e2e8f0;
+    }
+
+    .stat-label { color: #718096; }
+
+    .main {
+      padding: 16px 24px;
+      overflow-x: auto;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      min-width: 800px;
+    }
+
+    thead th {
+      text-align: left;
+      padding: 8px 12px;
+      color: #718096;
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      border-bottom: 1px solid #2d3748;
+      white-space: nowrap;
+    }
+
+    tbody tr {
+      border-bottom: 1px solid #1e2433;
+      transition: background 0.1s;
+    }
+
+    tbody tr:hover { background: #1a1f2e; }
+
+    td {
+      padding: 10px 12px;
+      vertical-align: top;
+      white-space: nowrap;
+    }
+
+    .ticket { font-weight: 600; color: #90cdf4; }
+
+    .badge {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: 10px;
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.03em;
+    }
+
+    .badge-running  { background: #1a365d; color: #63b3ed; }
+    .badge-complete { background: #1c4532; color: #68d391; }
+    .badge-failed   { background: #4a1515; color: #fc8181; }
+    .badge-stale    { background: #4a1515; color: #fbb6b6; }
+    .badge-checkpoint { background: #2d3748; color: #a0aec0; }
+    .badge-default  { background: #2d3748; color: #a0aec0; }
+
+    .stage { color: #a0aec0; }
+    .worktree { color: #718096; max-width: 240px; overflow: hidden; text-overflow: ellipsis; }
+    .ts { color: #718096; font-size: 12px; }
+    .pid { color: #a0aec0; }
+
+    .log-path {
+      color: #4a5568;
+      font-size: 11px;
+      max-width: 300px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      cursor: pointer;
+    }
+
+    .log-path:hover { color: #718096; }
+
+    .empty-state {
+      text-align: center;
+      padding: 60px 24px;
+      color: #4a5568;
+    }
+
+    .empty-state p { margin-top: 8px; font-size: 12px; }
+
+    footer {
+      padding: 12px 24px;
+      color: #4a5568;
+      font-size: 11px;
+      border-top: 1px solid #1e2433;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Fastflow <span>Monitor</span></h1>
+    <div class="refresh-indicator">
+      <div class="pulse-dot"></div>
+      <span id="last-refresh">Loading…</span>
+    </div>
+  </header>
+
+  <div class="stats-bar" id="stats-bar">
+    <div class="stat"><span class="stat-value" id="stat-total">—</span><span class="stat-label">total</span></div>
+    <div class="stat"><span class="stat-value" id="stat-running" style="color:#63b3ed">—</span><span class="stat-label">running</span></div>
+    <div class="stat"><span class="stat-value" id="stat-complete" style="color:#68d391">—</span><span class="stat-label">complete</span></div>
+    <div class="stat"><span class="stat-value" id="stat-failed" style="color:#fc8181">—</span><span class="stat-label">failed</span></div>
+    <div class="stat"><span class="stat-value" id="stat-stale" style="color:#fbb6b6">—</span><span class="stat-label">stale</span></div>
+  </div>
+
+  <div class="main">
+    <table id="runs-table">
+      <thead>
+        <tr>
+          <th>Ticket</th>
+          <th>Status</th>
+          <th>Stage</th>
+          <th>Worktree</th>
+          <th>Started</th>
+          <th>Updated</th>
+          <th>PID</th>
+          <th>Log</th>
+        </tr>
+      </thead>
+      <tbody id="runs-body">
+        <tr><td colspan="8"><div class="empty-state">Loading runs…</div></td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <footer>
+    <div class="pulse-dot" style="width:6px;height:6px;background:#4a5568"></div>
+    Auto-refreshing every 5s · Read-only monitor
+  </footer>
+
+  <script>
+    function badgeClass(status) {
+      switch (status) {
+        case 'running':    return 'badge-running';
+        case 'complete':   return 'badge-complete';
+        case 'failed':     return 'badge-failed';
+        case 'stale':      return 'badge-stale';
+        case 'checkpoint': return 'badge-checkpoint';
+        default:           return 'badge-default';
+      }
+    }
+
+    function shortenPath(p) {
+      if (!p) return '—';
+      const home = '/Users/';
+      const idx = p.indexOf(home);
+      if (idx !== -1) {
+        const afterHome = p.slice(idx + home.length);
+        const slash = afterHome.indexOf('/');
+        if (slash !== -1) return '~/' + afterHome.slice(slash + 1);
+      }
+      return p;
+    }
+
+    function formatTS(ts) {
+      if (!ts) return '—';
+      return ts.replace('T', ' ').slice(0, 19);
+    }
+
+    function render(runs) {
+      const tbody = document.getElementById('runs-body');
+
+      // Update stats
+      const counts = { running: 0, complete: 0, failed: 0, stale: 0 };
+      for (const r of runs) {
+        if (counts[r.status] !== undefined) counts[r.status]++;
+      }
+      document.getElementById('stat-total').textContent = runs.length;
+      document.getElementById('stat-running').textContent = counts.running;
+      document.getElementById('stat-complete').textContent = counts.complete;
+      document.getElementById('stat-failed').textContent = counts.failed;
+      document.getElementById('stat-stale').textContent = counts.stale;
+
+      if (runs.length === 0) {
+        tbody.innerHTML = '<tr><td colspan="8"><div class="empty-state">No runs found.<p>Start a fastflow run to see it here.</p></div></td></tr>';
+        return;
+      }
+
+      tbody.innerHTML = runs.map(r => `
+        <tr>
+          <td class="ticket">${esc(r.ticket)}</td>
+          <td><span class="badge ${badgeClass(r.status)}">${esc(r.status)}</span></td>
+          <td class="stage">${esc(r.stage || '—')}</td>
+          <td class="worktree" title="${esc(r.work_dir || '')}">${esc(shortenPath(r.work_dir))}</td>
+          <td class="ts">${esc(formatTS(r.created))}</td>
+          <td class="ts">${esc(formatTS(r.updated_at))}</td>
+          <td class="pid">${r.pid ? r.pid : '—'}</td>
+          <td class="log-path" title="${esc(r.log_path || '')}" onclick="copyText(this)">${esc(shortenPath(r.log_path))}</td>
+        </tr>
+      `).join('');
+    }
+
+    function esc(s) {
+      return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+    }
+
+    function copyText(el) {
+      const text = el.title || el.textContent;
+      if (navigator.clipboard) navigator.clipboard.writeText(text);
+    }
+
+    async function refresh() {
+      try {
+        const resp = await fetch('/api/runs');
+        if (!resp.ok) throw new Error('HTTP ' + resp.status);
+        const runs = await resp.json();
+        render(runs);
+        document.getElementById('last-refresh').textContent = 'Last refreshed ' + new Date().toLocaleTimeString();
+      } catch (e) {
+        document.getElementById('last-refresh').textContent = 'Error: ' + e.message;
+      }
+    }
+
+    refresh();
+    setInterval(refresh, 5000);
+  </script>
+</body>
+</html>

--- a/internal/monitor/discovery.go
+++ b/internal/monitor/discovery.go
@@ -1,0 +1,191 @@
+// Package monitor provides run discovery and web server for fastflow monitoring.
+package monitor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/redblacktree/fastflow/internal/runner"
+	"github.com/redblacktree/fastflow/internal/state"
+	"github.com/redblacktree/fastflow/internal/worktree"
+)
+
+// RunEntry represents a single run for display in both CLI and web UI.
+type RunEntry struct {
+	Ticket    string `json:"ticket"`
+	Status    string `json:"status"`
+	Stage     string `json:"stage"`
+	Created   string `json:"created"`
+	UpdatedAt string `json:"updated_at"`
+	Summary   string `json:"summary"`
+	Pid       int    `json:"pid,omitempty"`
+	LogPath   string `json:"log_path,omitempty"`
+	WorkDir   string `json:"work_dir,omitempty"`
+	RunDir    string `json:"run_dir,omitempty"`
+}
+
+// DiscoverRuns finds all runs across worktrees and state directories,
+// applies stale PID detection, and returns a unified list.
+// The prefix parameter filters entries by ticket prefix (empty = no filter).
+func DiscoverRuns(cwd, prefix string) ([]RunEntry, error) {
+	seen := make(map[string]bool)
+	var entries []RunEntry
+
+	// Source 1: Worktree-based runs via worktree.Manager.List()
+	mgr, err := worktree.NewManager(cwd)
+	if err == nil {
+		worktrees, err := mgr.List()
+		if err == nil {
+			for _, wt := range worktrees {
+				status := "active"
+				if wt.IsOrphan {
+					status = "orphaned"
+				}
+
+				created := ""
+				summary := "(no goal file)"
+				stage := ""
+				updatedAt := ""
+				workDir := wt.Path
+
+				// Try to read ticket info from goal.md
+				for _, loc := range []string{wt.Path, cwd} {
+					if info := worktree.ReadTicketInfo(loc, wt.Ticket); info != nil {
+						if info.Created != "" {
+							created = formatTimestamp(info.Created)
+						}
+						if info.Goal != "" {
+							summary = info.Goal
+						}
+						break
+					}
+				}
+
+				// Try to read state.json for richer status
+				runDir := runner.GetRunDir(wt.Path, wt.Ticket)
+				var entryPid int
+				if st, loadErr := state.Load(runDir); loadErr == nil && st != nil && st.Status != "" {
+					status = st.Status
+					stage = st.Stage
+					updatedAt = st.UpdatedAt
+					if st.WorkDir != "" {
+						workDir = st.WorkDir
+					}
+					// Detect stale runs: status is running but process is dead
+					if status == state.StatusRunning {
+						pid, _ := state.ReadPID(runDir)
+						if pid > 0 {
+							if !state.IsProcessAlive(pid) {
+								status = "stale"
+							} else {
+								entryPid = pid
+							}
+						}
+					}
+				}
+
+				var entryLogPath string
+				logPath := filepath.Join(runDir, "fastflow.log")
+				if _, statErr := os.Stat(logPath); statErr == nil {
+					entryLogPath = logPath
+				}
+
+				entries = append(entries, RunEntry{
+					Ticket:    wt.Ticket,
+					Status:    status,
+					Stage:     stage,
+					Created:   created,
+					UpdatedAt: updatedAt,
+					Summary:   summary,
+					Pid:       entryPid,
+					LogPath:   entryLogPath,
+					WorkDir:   workDir,
+					RunDir:    runDir,
+				})
+				seen[wt.Ticket] = true
+			}
+		}
+	}
+
+	// Source 2: State-based runs (non-worktree) from current repo
+	stateRuns, _ := state.ScanRunDirs(cwd)
+	for _, run := range stateRuns {
+		if seen[run.Ticket] {
+			continue // Already listed via worktree
+		}
+
+		status := run.State.Status
+		if status == "" {
+			status = "unknown"
+		}
+		// Detect stale runs: status is running but process is dead
+		var entryPid int
+		if status == state.StatusRunning {
+			pid, _ := state.ReadPID(run.RunDir)
+			if pid > 0 {
+				if !state.IsProcessAlive(pid) {
+					status = "stale"
+				} else {
+					entryPid = pid
+				}
+			}
+		}
+		stage := run.State.Stage
+		updatedAt := run.State.UpdatedAt
+		workDir := run.State.WorkDir
+		created := ""
+		summary := "(no goal file)"
+
+		// Read goal info
+		if info := worktree.ReadTicketInfo(cwd, run.Ticket); info != nil {
+			if info.Created != "" {
+				created = formatTimestamp(info.Created)
+			}
+			if info.Goal != "" {
+				summary = info.Goal
+			}
+		}
+
+		var entryLogPath string
+		logPath := filepath.Join(run.RunDir, "fastflow.log")
+		if _, statErr := os.Stat(logPath); statErr == nil {
+			entryLogPath = logPath
+		}
+
+		entries = append(entries, RunEntry{
+			Ticket:    run.Ticket,
+			Status:    status,
+			Stage:     stage,
+			Created:   created,
+			UpdatedAt: updatedAt,
+			Summary:   summary,
+			Pid:       entryPid,
+			LogPath:   entryLogPath,
+			WorkDir:   workDir,
+			RunDir:    run.RunDir,
+		})
+		seen[run.Ticket] = true
+	}
+
+	// Filter by prefix if specified
+	if prefix != "" {
+		var filtered []RunEntry
+		for _, e := range entries {
+			if strings.HasPrefix(e.Ticket, prefix) {
+				filtered = append(filtered, e)
+			}
+		}
+		entries = filtered
+	}
+
+	return entries, nil
+}
+
+// formatTimestamp normalizes a timestamp to "YYYY-MM-DD HH:MM:SS" for display.
+func formatTimestamp(ts string) string {
+	if len(ts) > 19 {
+		ts = ts[:19]
+	}
+	return strings.Replace(ts, "T", " ", 1)
+}

--- a/internal/monitor/discovery_test.go
+++ b/internal/monitor/discovery_test.go
@@ -1,0 +1,255 @@
+package monitor
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/redblacktree/fastflow/internal/state"
+)
+
+// makeRunDir creates a run directory under thoughts/shared/runs/<ticket>/ and returns its path.
+func makeRunDir(t *testing.T, root, ticket string) string {
+	t.Helper()
+	runDir := filepath.Join(root, "thoughts", "shared", "runs", ticket)
+	if err := os.MkdirAll(runDir, 0755); err != nil {
+		t.Fatalf("makeRunDir: %v", err)
+	}
+	return runDir
+}
+
+// writeState creates a state.json in runDir using the provided PipelineState.
+func writeState(t *testing.T, runDir string, st *state.PipelineState) {
+	t.Helper()
+	if err := st.Save(runDir); err != nil {
+		t.Fatalf("writeState: %v", err)
+	}
+}
+
+// writePID writes a PID file into runDir.
+func writePID(t *testing.T, runDir string, pid int) {
+	t.Helper()
+	path := filepath.Join(runDir, "pid")
+	if err := os.WriteFile(path, []byte(strconv.Itoa(pid)), 0644); err != nil {
+		t.Fatalf("writePID: %v", err)
+	}
+}
+
+// writeGoal writes a minimal goal.md file with the given goal and created timestamp.
+func writeGoal(t *testing.T, root, ticket, goal, created string) {
+	t.Helper()
+	runDir := filepath.Join(root, "thoughts", "shared", "runs", ticket)
+	if err := os.MkdirAll(runDir, 0755); err != nil {
+		t.Fatalf("writeGoal mkdir: %v", err)
+	}
+	content := "---\nticket: " + ticket + "\ngoal: " + goal + "\ncreated: " + created + "\n---\n\n# Goal\n\n" + goal + "\n"
+	if err := os.WriteFile(filepath.Join(runDir, "goal.md"), []byte(content), 0644); err != nil {
+		t.Fatalf("writeGoal: %v", err)
+	}
+}
+
+func TestDiscoverRuns_Empty(t *testing.T) {
+	root := t.TempDir()
+	entries, err := DiscoverRuns(root, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected 0 entries, got %d", len(entries))
+	}
+}
+
+func TestDiscoverRuns_SingleRun(t *testing.T) {
+	root := t.TempDir()
+	runDir := makeRunDir(t, root, "ENG-001")
+	st := state.NewState("plan-first", []string{"research", "plan", "implement"}, "ENG-001", root)
+	st.Status = state.StatusRunning
+	st.Stage = "plan"
+	writeState(t, runDir, st)
+
+	entries, err := DiscoverRuns(root, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	e := entries[0]
+	if e.Ticket != "ENG-001" {
+		t.Errorf("ticket: got %q, want %q", e.Ticket, "ENG-001")
+	}
+	if e.Status != state.StatusRunning {
+		t.Errorf("status: got %q, want %q", e.Status, state.StatusRunning)
+	}
+	if e.Stage != "plan" {
+		t.Errorf("stage: got %q, want %q", e.Stage, "plan")
+	}
+	if e.RunDir != runDir {
+		t.Errorf("run_dir: got %q, want %q", e.RunDir, runDir)
+	}
+}
+
+func TestDiscoverRuns_MultipleRuns(t *testing.T) {
+	root := t.TempDir()
+
+	tickets := []struct {
+		ticket string
+		status string
+	}{
+		{"ENG-001", state.StatusRunning},
+		{"ENG-002", state.StatusComplete},
+		{"ENG-003", state.StatusFailed},
+	}
+
+	for _, tc := range tickets {
+		runDir := makeRunDir(t, root, tc.ticket)
+		st := state.NewState("default", []string{"implement"}, tc.ticket, root)
+		st.Status = tc.status
+		writeState(t, runDir, st)
+	}
+
+	entries, err := DiscoverRuns(root, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(entries))
+	}
+
+	byTicket := make(map[string]RunEntry)
+	for _, e := range entries {
+		byTicket[e.Ticket] = e
+	}
+	for _, tc := range tickets {
+		e, ok := byTicket[tc.ticket]
+		if !ok {
+			t.Errorf("missing entry for %s", tc.ticket)
+			continue
+		}
+		if e.Status != tc.status {
+			t.Errorf("%s: status got %q, want %q", tc.ticket, e.Status, tc.status)
+		}
+	}
+}
+
+func TestDiscoverRuns_StaleDetection(t *testing.T) {
+	root := t.TempDir()
+	runDir := makeRunDir(t, root, "ENG-010")
+	st := state.NewState("default", []string{"implement"}, "ENG-010", root)
+	st.Status = state.StatusRunning
+	writeState(t, runDir, st)
+
+	// Write a PID that is guaranteed to be dead (PID 1 is init on Linux but
+	// sending signal 0 to it will fail from an unprivileged process on most
+	// systems; using a very high PID that almost certainly doesn't exist is
+	// safer and more portable).
+	writePID(t, runDir, 99999999)
+
+	entries, err := DiscoverRuns(root, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Status != "stale" {
+		t.Errorf("status: got %q, want %q", entries[0].Status, "stale")
+	}
+	if entries[0].Pid != 0 {
+		t.Errorf("pid should be 0 for stale run, got %d", entries[0].Pid)
+	}
+}
+
+func TestDiscoverRuns_PrefixFilter(t *testing.T) {
+	root := t.TempDir()
+
+	for _, ticket := range []string{"ENG-001", "ENG-002", "REL-100"} {
+		runDir := makeRunDir(t, root, ticket)
+		st := state.NewState("default", []string{"implement"}, ticket, root)
+		st.Status = state.StatusComplete
+		writeState(t, runDir, st)
+	}
+
+	entries, err := DiscoverRuns(root, "ENG-")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries with prefix ENG-, got %d", len(entries))
+	}
+	for _, e := range entries {
+		if e.Ticket == "REL-100" {
+			t.Errorf("REL-100 should be filtered out")
+		}
+	}
+}
+
+func TestDiscoverRuns_MissingStateFile(t *testing.T) {
+	root := t.TempDir()
+
+	// Create a run directory with NO state.json
+	noState := filepath.Join(root, "thoughts", "shared", "runs", "ENG-NOSTATE")
+	if err := os.MkdirAll(noState, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	// Create a valid one alongside it
+	runDir := makeRunDir(t, root, "ENG-VALID")
+	st := state.NewState("default", []string{"implement"}, "ENG-VALID", root)
+	st.Status = state.StatusComplete
+	writeState(t, runDir, st)
+
+	entries, err := DiscoverRuns(root, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry (skipping dir without state.json), got %d", len(entries))
+	}
+	if entries[0].Ticket != "ENG-VALID" {
+		t.Errorf("ticket: got %q, want ENG-VALID", entries[0].Ticket)
+	}
+}
+
+func TestDiscoverRuns_GoalParsing(t *testing.T) {
+	root := t.TempDir()
+	runDir := makeRunDir(t, root, "ENG-007")
+	st := state.NewState("default", []string{"implement"}, "ENG-007", root)
+	st.Status = state.StatusComplete
+	writeState(t, runDir, st)
+	writeGoal(t, root, "ENG-007", "Add OAuth login support", "2026-04-09T10:00:00-04:00")
+
+	entries, err := DiscoverRuns(root, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	e := entries[0]
+	if e.Summary != "Add OAuth login support" {
+		t.Errorf("summary: got %q, want %q", e.Summary, "Add OAuth login support")
+	}
+	if e.Created == "" {
+		t.Errorf("created should be set from goal.md")
+	}
+}
+
+func TestFormatTimestamp(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"2026-04-09T10:00:00-04:00", "2026-04-09 10:00:00"},
+		{"2026-04-09T10:00:00", "2026-04-09 10:00:00"},
+		{"2026-04-09", "2026-04-09"},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		got := formatTimestamp(tc.input)
+		if got != tc.want {
+			t.Errorf("formatTimestamp(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}

--- a/internal/monitor/server.go
+++ b/internal/monitor/server.go
@@ -1,0 +1,40 @@
+package monitor
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Server holds the configuration for the monitor web server.
+type Server struct {
+	Addr string // e.g. ":8080"
+	CWD  string // working directory for run discovery
+}
+
+// Start starts the HTTP server (blocking).
+func (s *Server) Start() error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/runs", s.handleAPIRuns)
+	mux.HandleFunc("/", s.handleDashboard)
+	return http.ListenAndServe(s.Addr, mux)
+}
+
+func (s *Server) handleAPIRuns(w http.ResponseWriter, r *http.Request) {
+	prefix := r.URL.Query().Get("prefix")
+	entries, err := DiscoverRuns(s.CWD, prefix)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	// Return [] instead of null for empty results
+	if entries == nil {
+		entries = []RunEntry{}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(entries) //nolint:errcheck
+}
+
+func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Write([]byte(dashboardHTML)) //nolint:errcheck
+}

--- a/internal/monitor/server_test.go
+++ b/internal/monitor/server_test.go
@@ -1,0 +1,151 @@
+package monitor
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/redblacktree/fastflow/internal/state"
+)
+
+func newTestServer(t *testing.T) (*Server, string) {
+	t.Helper()
+	root := t.TempDir()
+	return &Server{Addr: ":0", CWD: root}, root
+}
+
+func TestHandleAPIRuns_JSON(t *testing.T) {
+	srv, root := newTestServer(t)
+
+	// Create one run so the response is non-trivial
+	runDir := makeRunDir(t, root, "ENG-001")
+	st := state.NewState("default", []string{"implement"}, "ENG-001", root)
+	st.Status = state.StatusComplete
+	if err := st.Save(runDir); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/runs", nil)
+	rr := httptest.NewRecorder()
+	srv.handleAPIRuns(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status: got %d, want %d", rr.Code, http.StatusOK)
+	}
+	ct := rr.Header().Get("Content-Type")
+	if ct != "application/json" {
+		t.Errorf("Content-Type: got %q, want %q", ct, "application/json")
+	}
+
+	var entries []RunEntry
+	if err := json.Unmarshal(rr.Body.Bytes(), &entries); err != nil {
+		t.Fatalf("unmarshal: %v — body: %s", err, rr.Body.String())
+	}
+	if len(entries) != 1 {
+		t.Errorf("expected 1 entry, got %d", len(entries))
+	}
+}
+
+func TestHandleAPIRuns_PrefixParam(t *testing.T) {
+	srv, root := newTestServer(t)
+
+	for _, ticket := range []string{"ENG-001", "REL-100"} {
+		rd := makeRunDir(t, root, ticket)
+		st := state.NewState("default", []string{"implement"}, ticket, root)
+		st.Status = state.StatusComplete
+		if err := st.Save(rd); err != nil {
+			t.Fatalf("save state: %v", err)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/runs?prefix=ENG-", nil)
+	rr := httptest.NewRecorder()
+	srv.handleAPIRuns(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status: got %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	var entries []RunEntry
+	if err := json.Unmarshal(rr.Body.Bytes(), &entries); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("expected 1 entry after prefix filter, got %d", len(entries))
+	}
+	if len(entries) > 0 && entries[0].Ticket != "ENG-001" {
+		t.Errorf("ticket: got %q, want ENG-001", entries[0].Ticket)
+	}
+}
+
+func TestHandleAPIRuns_EmptyState(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/runs", nil)
+	rr := httptest.NewRecorder()
+	srv.handleAPIRuns(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status: got %d, want %d", rr.Code, http.StatusOK)
+	}
+
+	body := strings.TrimSpace(rr.Body.String())
+	// Should return [] not null
+	if body != "[]" {
+		t.Errorf("body: got %q, want %q", body, "[]")
+	}
+}
+
+func TestHandleDashboard_ServesHTML(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	srv.handleDashboard(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status: got %d, want %d", rr.Code, http.StatusOK)
+	}
+	ct := rr.Header().Get("Content-Type")
+	if !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("Content-Type: got %q, want text/html prefix", ct)
+	}
+	if !strings.Contains(rr.Body.String(), "Fastflow Monitor") {
+		t.Errorf("dashboard body should contain 'Fastflow Monitor'")
+	}
+}
+
+func TestHandleAPIRuns_LogPath(t *testing.T) {
+	srv, root := newTestServer(t)
+
+	runDir := makeRunDir(t, root, "ENG-LOG")
+	st := state.NewState("default", []string{"implement"}, "ENG-LOG", root)
+	st.Status = state.StatusComplete
+	if err := st.Save(runDir); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+	// Create a log file
+	logPath := filepath.Join(runDir, "fastflow.log")
+	if err := os.WriteFile(logPath, []byte("log output"), 0644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/runs", nil)
+	rr := httptest.NewRecorder()
+	srv.handleAPIRuns(rr, req)
+
+	var entries []RunEntry
+	if err := json.Unmarshal(rr.Body.Bytes(), &entries); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].LogPath != logPath {
+		t.Errorf("log_path: got %q, want %q", entries[0].LogPath, logPath)
+	}
+}


### PR DESCRIPTION
## What problem does this solve?

There was no way to get a real-time view of which fastflow runs were in-flight across worktrees. The only option was `fastflow list`, a terminal-only snapshot with no auto-refresh.

## What changed?

### New: `internal/monitor` package

A self-contained package with three responsibilities:

- **`DiscoverRuns`** — scans worktrees and state directories, deduplicates entries by ticket, and marks runs as `stale` when the recorded PID is no longer alive. This logic was previously duplicated inline inside `runList` in `main.go`.
- **`Server`** — lightweight `net/http` server. Serves an HTML dashboard at `/` and a JSON API at `/api/runs` (supports `?prefix=` filtering).
- **HTML dashboard** — auto-refreshes every 5 s; shows ticket, status, stage, started/updated timestamps, PID (if live), and log file path for each run. Read-only — no destructive controls.

### Changed: `cmd/fastflow/main.go`

- Adds `fastflow monitor [--addr :8080]` command that starts the monitor server.
- Refactors `fastflow list` to delegate run discovery to `monitor.DiscoverRuns`, removing ~160 lines of duplicated logic.

### Changed: `README.md`

Documents the `monitor` command, `--addr` flag, and the `/api/runs` JSON API.

## How to verify it

- [x] `go build ./...` — compiles cleanly
- [x] `go test ./internal/monitor/...` — all tests pass
- [ ] Manual: `fastflow monitor`, open `http://localhost:8080`, confirm dashboard loads and shows active runs
- [ ] Manual: `curl http://localhost:8080/api/runs` returns valid JSON array
- [ ] Manual: `fastflow list` still works correctly (refactored to use `monitor.DiscoverRuns`)

## Notes

- v1 is read-only by design (no destructive controls).
- Stale run detection (PID dead but status still `running`) is handled in `DiscoverRuns` and surfaced in both the dashboard and `fastflow list`.
- No new external dependencies introduced.