### PR TITLE
feat: workspace-trust guardrail and background run e2e tests (REL-548)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,16 @@ go test ./...
 ./fastflow validate
 ```
 
+## Working directories
+
+fastflow's workspace-trust guardrail (`internal/workspace/trust.go`) checks the resolved working directory against a list of blocked path prefixes before any run starts. This prevents accidental runs against stale workspace mirrors (e.g. `~/.openclaw/workspace/*`).
+
+When writing tests or tooling that invokes `fastflow run`:
+
+- **Always use the canonical repo worktree** (e.g. `/Users/you/repos/fastflow` or a worktree under `/Users/you/wt/fastflow/`). Do not invoke fastflow from a path inside a stale mirror.
+- If you need to test the guardrail itself, see `internal/workspace/trust_test.go` for examples of how to construct a temporary git repo and verify that blocked prefixes are refused.
+- The `--allow-untrusted-workspace` flag (or `FASTFLOW_ALLOW_UNTRUSTED_WORKSPACE=1`) exists for integration tests that must run from an arbitrary directory; avoid using it in production scripts.
+
 ## Code Style
 
 - Follow standard Go conventions

--- a/README.md
+++ b/README.md
@@ -68,6 +68,40 @@ fastflow run --goal "Fix login timeout bug" --ticket ENG-1236 --workflow debug
 fastflow run --goal "Refactor auth system" --ticket ENG-1237 --no-review
 ```
 
+### Background runs
+
+To launch a workflow in the background (detached from the terminal), pass `--background`:
+
+```bash
+fastflow run --goal "Add user authentication" --ticket ENG-1234 --background
+```
+
+fastflow re-execs itself as a detached process, writes all output to `fastflow.log` inside the run directory, and returns immediately. Use `fastflow monitor` to track progress.
+
+### Workspace trust
+
+By default fastflow accepts any working directory. In environments where runs must be confined to trusted paths (e.g. to prevent a stale workspace mirror from being targeted accidentally), use the blocked-prefix guardrail:
+
+```bash
+# Block a specific path prefix at invocation time
+fastflow run --goal "..." --ticket ENG-1 \
+  --blocked-workspace-prefix /Users/me/.openclaw
+
+# Block multiple prefixes (repeat the flag)
+fastflow run --goal "..." --ticket ENG-1 \
+  --blocked-workspace-prefix /tmp \
+  --blocked-workspace-prefix /private/tmp
+```
+
+The same prefixes can be set via the environment variable `FASTFLOW_BLOCKED_WORKSPACE_PREFIXES` (colon-separated list):
+
+```bash
+export FASTFLOW_BLOCKED_WORKSPACE_PREFIXES=/Users/me/.openclaw:/tmp
+fastflow run --goal "..." --ticket ENG-1
+```
+
+If the resolved working directory falls under any blocked prefix, `fastflow run` exits immediately with a non-zero status. To bypass the check in a trusted one-off scenario, pass `--allow-untrusted-workspace` (or set `FASTFLOW_ALLOW_UNTRUSTED_WORKSPACE=1`).
+
 ### Validate configuration
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ fastflow re-execs itself as a detached process, writes all output to `fastflow.l
 
 ### Workspace trust
 
-By default fastflow accepts any working directory. In environments where runs must be confined to trusted paths (e.g. to prevent a stale workspace mirror from being targeted accidentally), use the blocked-prefix guardrail:
+By default `fastflow run` only starts from a git workspace that has an `origin` remote. This catches accidental runs from scratch directories or stale mirrors before fastflow creates state or worktrees. In environments where runs must also be confined away from specific paths (for example, to prevent a stale `.openclaw` workspace mirror from being targeted accidentally), add blocked-prefix guardrails:
 
 ```bash
 # Block a specific path prefix at invocation time
@@ -100,7 +100,7 @@ export FASTFLOW_BLOCKED_WORKSPACE_PREFIXES=/Users/me/.openclaw:/tmp
 fastflow run --goal "..." --ticket ENG-1
 ```
 
-If the resolved working directory falls under any blocked prefix, `fastflow run` exits immediately with a non-zero status. To bypass the check in a trusted one-off scenario, pass `--allow-untrusted-workspace` (or set `FASTFLOW_ALLOW_UNTRUSTED_WORKSPACE=1`).
+If the resolved working directory has no git `origin` remote or falls under any blocked prefix, `fastflow run` exits immediately with a non-zero status. To bypass the workspace-trust checks in a trusted one-off scenario, pass `--allow-untrusted-workspace` (or set `FASTFLOW_ALLOW_UNTRUSTED_WORKSPACE=1`).
 
 ### Validate configuration
 

--- a/cmd/fastflow/background_e2e_test.go
+++ b/cmd/fastflow/background_e2e_test.go
@@ -1,0 +1,238 @@
+//go:build !windows
+
+package main_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestBackgroundReExecEndToEnd(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Initialize a minimal git repo so workspace trust / origin lookups don't error.
+	repo := filepath.Join(tmp, "repo")
+	mustRun(t, tmp, "git", "init", repo)
+	mustRun(t, repo, "git", "config", "user.email", "t@t")
+	mustRun(t, repo, "git", "config", "user.name", "t")
+	mustRun(t, repo, "git", "remote", "add", "origin", "https://github.com/x/y.git")
+	if err := os.WriteFile(filepath.Join(repo, "README"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mustRun(t, repo, "git", "add", ".")
+	mustRun(t, repo, "git", "commit", "-m", "init")
+
+	writeMinimalConfig(t, repo)
+
+	// Build the binary into the temp dir.
+	bin := filepath.Join(tmp, "fastflow")
+	build := exec.Command("go", "build", "-o", bin, "./cmd/fastflow")
+	build.Dir = projectRoot(t)
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build failed: %v\n%s", err, out)
+	}
+
+	// Run parent with --background; parent should exit 0 immediately.
+	// Explicitly clear FASTFLOW_DAEMONIZED so the parent actually forks even
+	// when the test itself is running inside a fastflow background process.
+	cmd := exec.Command(bin,
+		"run",
+		"--ticket", "BG-SMOKE",
+		"--goal", "smoke",
+		"--no-worktree",
+		"--dry-run",
+		"--background",
+	)
+	cmd.Dir = repo
+	cmd.Env = stripEnv(os.Environ(), "FASTFLOW_DAEMONIZED")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("parent exited non-zero: %v\n%s", err, out)
+	}
+
+	pid := parseChildPID(t, string(out))
+	t.Logf("child pid = %d", pid)
+
+	// The parent creates fastflow.log before spawning the child, so it should
+	// appear very quickly after the parent exits.
+	logPath := filepath.Join(repo, "thoughts", "shared", "runs", "BG-SMOKE", "fastflow.log")
+	waitForFile(t, logPath, 5*time.Second)
+
+	// Wait for the dry-run child to finish (completes in well under 10s).
+	waitForExit(t, pid, 10*time.Second)
+}
+
+// TestRunRefusesBlockedWorkspace verifies the workspace-trust guardrail added
+// in Phase 2: fastflow run exits non-zero from a blocked prefix and succeeds
+// with --allow-untrusted-workspace.
+func TestRunRefusesBlockedWorkspace(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Create a git repo inside a "blocked" directory.
+	blocked := filepath.Join(tmp, "blocked")
+	repo := filepath.Join(blocked, "fastflow")
+	mustRun(t, tmp, "git", "init", repo)
+	mustRun(t, repo, "git", "config", "user.email", "t@t")
+	mustRun(t, repo, "git", "config", "user.name", "t")
+	mustRun(t, repo, "git", "remote", "add", "origin", "https://github.com/x/y.git")
+	if err := os.WriteFile(filepath.Join(repo, "README"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mustRun(t, repo, "git", "add", ".")
+	mustRun(t, repo, "git", "commit", "-m", "init")
+
+	writeMinimalConfig(t, repo)
+
+	bin := filepath.Join(tmp, "fastflow")
+	build := exec.Command("go", "build", "-o", bin, "./cmd/fastflow")
+	build.Dir = projectRoot(t)
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build failed: %v\n%s", err, out)
+	}
+
+	// Run from inside the blocked prefix — should fail.
+	cmd := exec.Command(bin,
+		"run",
+		"--ticket", "BLOCK-TEST",
+		"--goal", "smoke",
+		"--no-worktree",
+		"--dry-run",
+		"--blocked-workspace-prefix", blocked,
+	)
+	cmd.Dir = repo
+	cmd.Env = stripEnv(os.Environ(), "FASTFLOW_DAEMONIZED")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected non-zero exit for blocked workspace, got success\n%s", out)
+	}
+	if !regexp.MustCompile(`blocked prefix`).Match(out) {
+		t.Errorf("expected 'blocked prefix' in output, got:\n%s", out)
+	}
+
+	// Same command with --allow-untrusted-workspace should pass the trust check.
+	cmd2 := exec.Command(bin,
+		"run",
+		"--ticket", "BLOCK-TEST",
+		"--goal", "smoke",
+		"--no-worktree",
+		"--dry-run",
+		"--blocked-workspace-prefix", blocked,
+		"--allow-untrusted-workspace",
+	)
+	cmd2.Dir = repo
+	cmd2.Env = stripEnv(os.Environ(), "FASTFLOW_DAEMONIZED")
+	out2, err2 := cmd2.CombinedOutput()
+	if err2 != nil {
+		t.Fatalf("expected success with --allow-untrusted-workspace, got: %v\n%s", err2, out2)
+	}
+}
+
+// --- helpers ---
+
+func parseChildPID(t *testing.T, out string) int {
+	t.Helper()
+	re := regexp.MustCompile(`PID (\d+)`)
+	m := re.FindStringSubmatch(out)
+	if len(m) != 2 {
+		t.Fatalf("could not find PID in output:\n%s", out)
+	}
+	pid, _ := strconv.Atoi(m[1])
+	if pid <= 0 {
+		t.Fatalf("invalid pid: %d", pid)
+	}
+	return pid
+}
+
+func waitForExit(t *testing.T, pid int, d time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(pid, 0); err != nil {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	_ = syscall.Kill(pid, syscall.SIGTERM)
+	t.Fatalf("child %d did not exit within %s", pid, d)
+}
+
+func waitForFile(t *testing.T, path string, d time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("file %s did not appear within %s", path, d)
+}
+
+func mustRun(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("command %v failed: %v\n%s", args, err, out)
+	}
+}
+
+func writeMinimalConfig(t *testing.T, dir string) {
+	t.Helper()
+	const cfg = `{
+  "default_workflow": "smoke",
+  "workflows": {
+    "smoke": {
+      "description": "Smoke test workflow",
+      "stages": ["noop"],
+      "skip_goal": true
+    }
+  },
+  "stages": {
+    "noop": {
+      "skill": "noop"
+    }
+  }
+}`
+	if err := os.WriteFile(filepath.Join(dir, "orchestrator.json"), []byte(cfg), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func projectRoot(t *testing.T) string {
+	t.Helper()
+	// Tests run with working dir set to the package directory (cmd/fastflow).
+	// The project root is two levels up.
+	abs, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return abs
+}
+
+// stripEnv returns os.Environ() with the named key(s) removed. Used to ensure
+// test subprocesses are not contaminated by vars set by a parent fastflow run.
+func stripEnv(env []string, keys ...string) []string {
+	skip := make(map[string]bool, len(keys))
+	for _, k := range keys {
+		skip[k] = true
+	}
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
+		key := kv
+		if i := strings.Index(kv, "="); i >= 0 {
+			key = kv[:i]
+		}
+		if !skip[key] {
+			out = append(out, kv)
+		}
+	}
+	return out
+}

--- a/cmd/fastflow/main.go
+++ b/cmd/fastflow/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/redblacktree/fastflow/internal/runner"
 	"github.com/redblacktree/fastflow/internal/state"
 	"github.com/redblacktree/fastflow/internal/templates"
+	"github.com/redblacktree/fastflow/internal/workspace"
 	"github.com/redblacktree/fastflow/internal/worktree"
 	"github.com/spf13/cobra"
 )
@@ -208,14 +209,16 @@ var (
 	flagCleanPrefix string
 	flagCleanForce  bool
 	flagNoWorktree  bool
-	flagNoFetch     bool
-	flagVerbose     bool
-	flagLogFile     string
-	flagNoColor     bool
-	flagRunForce    bool
-	flagOnComplete  string
-	flagBackground  bool
-	flagMonitorAddr string
+	flagNoFetch                 bool
+	flagVerbose                 bool
+	flagLogFile                 string
+	flagNoColor                 bool
+	flagRunForce                bool
+	flagOnComplete              string
+	flagBackground              bool
+	flagBlockedWorkspacePrefix  []string
+	flagAllowUntrustedWorkspace bool
+	flagMonitorAddr             string
 )
 
 func init() {
@@ -251,6 +254,10 @@ func init() {
 			"FASTFLOW_STATUS, FASTFLOW_WORKTREE, FASTFLOW_RUN_DIR, FASTFLOW_ERROR, "+
 			"FASTFLOW_WORKFLOW. Times out after 5 minutes. See README for examples.")
 	runCmd.Flags().BoolVar(&flagBackground, "background", false, "Run in background (detach from terminal)")
+	runCmd.Flags().StringArrayVar(&flagBlockedWorkspacePrefix, "blocked-workspace-prefix", nil,
+		"Refuse to run when cwd is under any of these path prefixes (repeatable; supports ~/)")
+	runCmd.Flags().BoolVar(&flagAllowUntrustedWorkspace, "allow-untrusted-workspace", false,
+		"Bypass workspace-trust validation (no origin remote / blocked prefix)")
 
 	// Only ticket is required - goal can come from multiple sources
 	_ = runCmd.MarkFlagRequired("ticket")
@@ -476,6 +483,21 @@ func runRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to get working directory: %w", err)
 	}
 
+	// Verify workspace trust before mutating any state.
+	trustOpts := workspace.TrustOpts{
+		BlockedPrefixes: append(flagBlockedWorkspacePrefix,
+			splitColonList(os.Getenv("FASTFLOW_BLOCKED_WORKSPACE_PREFIXES"))...),
+		Allow: flagAllowUntrustedWorkspace || os.Getenv("FASTFLOW_ALLOW_UNTRUSTED_WORKSPACE") == "1",
+	}
+	trust, err := workspace.VerifyTrustedWorkspace(cwd, trustOpts)
+	if err != nil {
+		return fmt.Errorf("%s %v", errColor("ERROR"), err)
+	}
+	output.Printf("    Repo:   %s\n", trust.RepoRoot)
+	if trust.OriginURL != "" {
+		output.Printf("    Origin: %s\n", trust.OriginURL)
+	}
+
 	// Setup worktree (or use current directory)
 	workDir := cwd
 	branchName := flagTicket
@@ -643,6 +665,20 @@ func runRun(cmd *cobra.Command, args []string) error {
 		return r.RunSingleStage(ctx)
 	}
 	return r.Run(ctx)
+}
+
+// splitColonList splits a colon-separated list, ignoring empty elements.
+func splitColonList(s string) []string {
+	if s == "" {
+		return nil
+	}
+	var out []string
+	for _, part := range strings.Split(s, ":") {
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
 }
 
 func runValidate(cmd *cobra.Command, args []string) error {

--- a/cmd/fastflow/main.go
+++ b/cmd/fastflow/main.go
@@ -193,22 +193,22 @@ Examples:
 
 // Flags
 var (
-	flagGoal        string
-	flagGoalFile    string
-	flagTicket      string
-	flagWorkflow    string
-	flagStage       string
-	flagNoReview    bool
-	flagConfigPath  string
-	flagDryRun      bool
-	flagDebug       bool
-	flagResume      string
-	flagInteractive bool
-	flagInitForce   bool
-	flagListPrefix  string
-	flagCleanPrefix string
-	flagCleanForce  bool
-	flagNoWorktree  bool
+	flagGoal                    string
+	flagGoalFile                string
+	flagTicket                  string
+	flagWorkflow                string
+	flagStage                   string
+	flagNoReview                bool
+	flagConfigPath              string
+	flagDryRun                  bool
+	flagDebug                   bool
+	flagResume                  string
+	flagInteractive             bool
+	flagInitForce               bool
+	flagListPrefix              string
+	flagCleanPrefix             string
+	flagCleanForce              bool
+	flagNoWorktree              bool
 	flagNoFetch                 bool
 	flagVerbose                 bool
 	flagLogFile                 string

--- a/internal/workspace/trust.go
+++ b/internal/workspace/trust.go
@@ -1,0 +1,135 @@
+// Package workspace provides workspace-trust validation so fastflow
+// refuses to operate inside ignored mirrors or directories with no git origin.
+package workspace
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+var (
+	ErrNoOrigin      = errors.New("workspace has no git origin remote")
+	ErrBlockedPrefix = errors.New("workspace is under a blocked prefix")
+)
+
+// TrustOpts controls how VerifyTrustedWorkspace behaves.
+type TrustOpts struct {
+	// BlockedPrefixes are raw path entries (may contain ~) from flag/env.
+	// A run is refused when the cwd is under any of these prefixes.
+	BlockedPrefixes []string
+	// Allow bypasses all trust checks (--allow-untrusted-workspace).
+	Allow bool
+}
+
+// TrustInfo is returned by VerifyTrustedWorkspace on success.
+type TrustInfo struct {
+	RepoRoot  string
+	OriginURL string
+	// BlockedBy is set when ErrBlockedPrefix is returned.
+	BlockedBy string
+}
+
+// VerifyTrustedWorkspace confirms that cwd is a real git clone with an origin
+// remote and is not under any operator-configured blocked prefix.
+func VerifyTrustedWorkspace(cwd string, opts TrustOpts) (TrustInfo, error) {
+	info := TrustInfo{}
+
+	root, err := gitRevParseShowToplevel(cwd)
+	if err == nil && root != "" {
+		info.RepoRoot = root
+	} else {
+		info.RepoRoot = cwd
+	}
+
+	if opts.Allow {
+		// Still populate origin for logging, but never fail.
+		info.OriginURL, _ = gitOriginURL(info.RepoRoot)
+		return info, nil
+	}
+
+	originURL, err := gitOriginURL(info.RepoRoot)
+	if err != nil || originURL == "" {
+		return info, fmt.Errorf("%w: %s (set --allow-untrusted-workspace to bypass)",
+			ErrNoOrigin, info.RepoRoot)
+	}
+	info.OriginURL = originURL
+
+	absCwd := resolvedAbs(info.RepoRoot)
+	for _, raw := range opts.BlockedPrefixes {
+		expanded := expandTilde(strings.TrimSpace(raw))
+		if expanded == "" {
+			continue
+		}
+		absPrefix := resolvedAbs(expanded)
+		if absPrefix == "" {
+			continue
+		}
+		if pathHasPrefix(absCwd, absPrefix) {
+			info.BlockedBy = absPrefix
+			return info, fmt.Errorf("%w: %s is under blocked prefix %s (set --allow-untrusted-workspace to bypass)",
+				ErrBlockedPrefix, absCwd, absPrefix)
+		}
+	}
+
+	return info, nil
+}
+
+func gitRevParseShowToplevel(dir string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func gitOriginURL(dir string) (string, error) {
+	cmd := exec.Command("git", "remote", "get-url", "origin")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func expandTilde(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return path
+		}
+		return filepath.Join(home, path[2:])
+	}
+	return path
+}
+
+// resolvedAbs returns the absolute, symlink-resolved form of path, or the
+// cleaned absolute path if symlink resolution fails.
+func resolvedAbs(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return ""
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return abs
+	}
+	return resolved
+}
+
+// pathHasPrefix returns true if p is equal to or a descendant of prefix,
+// comparing on clean segment boundaries so /a/bcd is not under /a/b.
+func pathHasPrefix(p, prefix string) bool {
+	p = filepath.Clean(p)
+	prefix = filepath.Clean(prefix)
+	if p == prefix {
+		return true
+	}
+	return strings.HasPrefix(p, prefix+string(filepath.Separator))
+}

--- a/internal/workspace/trust_test.go
+++ b/internal/workspace/trust_test.go
@@ -1,0 +1,137 @@
+package workspace
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// initGitRepo creates a git repo at dir with the given origin URL (may be empty).
+func initGitRepo(t *testing.T, dir, originURL string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("command %v: %v\n%s", args, err, out)
+		}
+	}
+	run("git", "init")
+	run("git", "config", "user.email", "t@t")
+	run("git", "config", "user.name", "t")
+	if originURL != "" {
+		run("git", "remote", "add", "origin", originURL)
+	}
+	// Commit so the repo has a HEAD.
+	if err := os.WriteFile(filepath.Join(dir, ".keep"), nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+	run("git", "add", ".")
+	run("git", "commit", "-m", "init")
+}
+
+func TestVerifyTrustedWorkspace_HappyPath(t *testing.T) {
+	tmp := t.TempDir()
+	initGitRepo(t, tmp, "https://github.com/x/y.git")
+
+	info, err := VerifyTrustedWorkspace(tmp, TrustOpts{})
+	if err != nil {
+		t.Fatalf("want nil error, got %v", err)
+	}
+	if info.OriginURL != "https://github.com/x/y.git" {
+		t.Errorf("want origin URL, got %q", info.OriginURL)
+	}
+	if info.RepoRoot == "" {
+		t.Error("RepoRoot should be set")
+	}
+}
+
+func TestVerifyTrustedWorkspace_NoRemote(t *testing.T) {
+	tmp := t.TempDir()
+	initGitRepo(t, tmp, "") // no origin
+
+	_, err := VerifyTrustedWorkspace(tmp, TrustOpts{})
+	if !errors.Is(err, ErrNoOrigin) {
+		t.Fatalf("want ErrNoOrigin, got %v", err)
+	}
+}
+
+func TestVerifyTrustedWorkspace_NonGitDir(t *testing.T) {
+	tmp := t.TempDir()
+	// Plain directory, not a git repo.
+	_, err := VerifyTrustedWorkspace(tmp, TrustOpts{})
+	if !errors.Is(err, ErrNoOrigin) {
+		t.Fatalf("want ErrNoOrigin for non-git dir, got %v", err)
+	}
+}
+
+func TestVerifyTrustedWorkspace_BlockedPrefix(t *testing.T) {
+	tmp := t.TempDir()
+	repo := filepath.Join(tmp, "blocked", "fastflow")
+	initGitRepo(t, repo, "https://github.com/x/y.git")
+
+	info, err := VerifyTrustedWorkspace(repo, TrustOpts{
+		BlockedPrefixes: []string{filepath.Join(tmp, "blocked")},
+	})
+	if !errors.Is(err, ErrBlockedPrefix) {
+		t.Fatalf("want ErrBlockedPrefix, got %v", err)
+	}
+	if info.BlockedBy == "" {
+		t.Error("BlockedBy should be set")
+	}
+}
+
+func TestVerifyTrustedWorkspace_SiblingNotBlocked(t *testing.T) {
+	// /a/bcd should NOT be blocked by prefix /a/b.
+	tmp := t.TempDir()
+	prefix := filepath.Join(tmp, "a", "b")
+	repo := filepath.Join(tmp, "a", "bcd")
+	initGitRepo(t, repo, "https://github.com/x/y.git")
+
+	_, err := VerifyTrustedWorkspace(repo, TrustOpts{
+		BlockedPrefixes: []string{prefix},
+	})
+	if err != nil {
+		t.Fatalf("sibling path should not be blocked, got %v", err)
+	}
+}
+
+func TestVerifyTrustedWorkspace_AllowBypassesBothChecks(t *testing.T) {
+	tmp := t.TempDir()
+	// Not a git repo at all — but Allow=true should skip all checks.
+	info, err := VerifyTrustedWorkspace(tmp, TrustOpts{
+		BlockedPrefixes: []string{tmp},
+		Allow:           true,
+	})
+	if err != nil {
+		t.Fatalf("Allow=true should bypass all checks, got %v", err)
+	}
+	if info.BlockedBy != "" {
+		t.Error("BlockedBy should not be set when Allow=true")
+	}
+}
+
+func TestPathHasPrefix(t *testing.T) {
+	cases := []struct {
+		p, prefix string
+		want      bool
+	}{
+		{"/a/b/c", "/a/b", true},
+		{"/a/b", "/a/b", true},
+		{"/a/bcd", "/a/b", false},
+		{"/a/b", "/a/b/c", false},
+		{"/", "/a", false},
+	}
+	for _, c := range cases {
+		got := pathHasPrefix(c.p, c.prefix)
+		if got != c.want {
+			t.Errorf("pathHasPrefix(%q, %q) = %v, want %v", c.p, c.prefix, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## What problem does this solve?

A previous attempt at this ticket produced no usable diff or PR because the work landed in a stale workspace mirror at `~/.openclaw/workspace/fastflow` instead of the real clone. The CLI provided no signal about which directory it was executing from, and no guard against running from such a mirror. This PR addresses that failure mode with the smallest durable fix.

Background run support (`--background`) was already shipped in REL-361 and is not regressed — but the existing background tests only verified flag registration, not the actual re-exec path. A future change to `runRun` could silently break background mode without any test catching it.

## What changed?

### `internal/workspace` (new package)

`VerifyTrustedWorkspace(cwd string, opts TrustOpts) (TrustInfo, error)` checks two things at the start of every `fastflow run`:

1. **Origin check** — resolves `git remote get-url origin` for the cwd. If there is no origin remote, the run is refused. This catches the case where fastflow is driven against a bare directory or an auto-replicated clone with no upstream.
2. **Blocked-prefix check** — if the cwd descends from any operator-configured prefix (flag or env var), the run is refused. Path comparison is done on cleaned segment boundaries so `/a/bcd` is not falsely blocked by prefix `/a/b`.

`--allow-untrusted-workspace` (or `FASTFLOW_ALLOW_UNTRUSTED_WORKSPACE=1`) bypasses both checks for intentional exceptions.

### `cmd/fastflow/main.go`

- Two new flags on `fastflow run`:
  - `--blocked-workspace-prefix` (repeatable, supports `~/`)
  - `--allow-untrusted-workspace`
- Reads `FASTFLOW_BLOCKED_WORKSPACE_PREFIXES` (colon-separated) and `FASTFLOW_ALLOW_UNTRUSTED_WORKSPACE` from the environment.
- Prints `Repo:` and `Origin:` early in the run output so the resolved clone is visible in `fastflow.log` for background runs.

### `cmd/fastflow/background_e2e_test.go` (new)

Two end-to-end tests that build the real binary and exercise it against a minimal git repo in a temp dir:

- `TestBackgroundReExecEndToEnd` — full `--background` flow: parent exits 0, child PID is live, `fastflow.log` appears under the run dir. Explicitly strips `FASTFLOW_DAEMONIZED` from the env so the test is safe to run inside a fastflow background process.
- `TestRunRefusesBlockedWorkspace` — asserts non-zero exit + `"blocked prefix"` in output when cwd is under a blocked prefix; asserts success with `--allow-untrusted-workspace`.

### Documentation

- `README.md`: new `### Background runs` and `### Workspace trust` subsections under `## Usage`.
- `CONTRIBUTING.md`: new `## Working directories` section explaining canonical clone vs worktree paths and how to avoid stale mirrors.

## How to verify it

- [x] `go build ./cmd/fastflow` — clean build
- [x] `go test ./...` — all packages green (11/11)
- [x] `go test ./internal/workspace/...` — 6 unit tests covering happy path, no-remote, non-git-dir, blocked prefix, sibling-path false-positive, and `Allow` bypass
- [x] `go test ./cmd/fastflow/...` — includes `TestBackgroundReExecEndToEnd` and `TestRunRefusesBlockedWorkspace`
- [ ] Manual: from a non-git directory, `fastflow run --ticket TEST --goal x --no-worktree --dry-run` exits non-zero with "workspace has no git origin remote"
- [ ] Manual: same command with `--allow-untrusted-workspace` — trust error is gone
- [ ] Manual: `fastflow run --ticket BG-MANUAL --goal smoke --no-worktree --dry-run --background` from real repo — parent prints `PID`, exits 0; `fastflow.log` contains `Repo:` and `Origin:` lines
- [ ] Manual: PR diff shows only the six intended files (`cmd/fastflow/main.go`, `cmd/fastflow/background_e2e_test.go`, `internal/workspace/trust.go`, `internal/workspace/trust_test.go`, `README.md`, `CONTRIBUTING.md`)

## Changelog

- feat(REL-548): add workspace-trust guardrail to `fastflow run` with `--blocked-workspace-prefix` / `FASTFLOW_BLOCKED_WORKSPACE_PREFIXES` support; surface resolved repo root and origin on every run
- feat(REL-548): add real e2e smoke test for `--background` re-exec path
- docs(REL-548): document background runs and workspace trust in README and CONTRIBUTING