### PR TITLE
feat: restore and harden --on-complete hook for fastflow runs (REL-549)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,52 @@ fastflow run --goal "Refactor auth system" --ticket ENG-1237 --no-review
 fastflow validate
 ```
 
+### Run an on-completion hook
+
+Use `--on-complete` to fire a shell command after a run finishes (success, failure, or signal-driven termination). Useful for Slack notifications, hand-off automation, or cleanup tasks for long-lived runs.
+
+```bash
+fastflow run --goal "Add feature X" --ticket ENG-1234 \
+  --on-complete 'curl -X POST -d "ticket=$FASTFLOW_TICKET status=$FASTFLOW_STATUS" https://hooks.slack.com/services/...'
+```
+
+The command is executed via `sh -c` and receives these environment variables:
+
+| Variable            | Value                                                        |
+|---------------------|--------------------------------------------------------------|
+| `FASTFLOW_TICKET`   | The ticket identifier passed via `--ticket`                  |
+| `FASTFLOW_STATUS`   | `complete` on success, `failed` on error or signal           |
+| `FASTFLOW_WORKTREE` | Absolute path to the run's working directory (worktree root) |
+| `FASTFLOW_RUN_DIR`  | Absolute path to the run artifact directory (`thoughts/...`) |
+| `FASTFLOW_ERROR`    | Error message when `STATUS=failed`, empty on success         |
+| `FASTFLOW_WORKFLOW` | Workflow name (e.g., `full`, `plan-first`)                   |
+| `FASTFLOW_PR_URL`   | Reserved (currently empty)                                   |
+
+Behavior:
+
+- The hook fires on every terminal outcome, including `SIGTERM`/`SIGINT` shutdown of long-lived `--background` runs.
+- The command is persisted in `state.json`, so it survives `--resume`.
+- The command has a 5-minute execution budget; if it exceeds that, it is killed with a warning and the run continues to exit normally.
+- Hook failures (non-zero exit, timeout) are logged as warnings and do **not** affect fastflow's own exit code.
+
+Examples:
+
+```bash
+# Append outcome to a log file
+fastflow run --ticket ENG-100 --goal "..." \
+  --on-complete 'echo "$(date) $FASTFLOW_TICKET=$FASTFLOW_STATUS" >> ~/fastflow.log'
+
+# Open the run directory in your editor on failure
+fastflow run --ticket ENG-101 --goal "..." \
+  --on-complete '[ "$FASTFLOW_STATUS" = "failed" ] && code "$FASTFLOW_RUN_DIR"'
+
+# Fire-and-forget Slack notification (background run)
+fastflow run --ticket ENG-102 --goal "..." --background \
+  --on-complete 'curl -fsSL -X POST -H "Content-Type: application/json" \
+    -d "{\"text\":\"$FASTFLOW_TICKET finished: $FASTFLOW_STATUS\"}" \
+    "$SLACK_WEBHOOK_URL"'
+```
+
 ### Monitor
 
 Start a web dashboard for monitoring in-flight fastflow runs:

--- a/cmd/fastflow/main.go
+++ b/cmd/fastflow/main.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/fatih/color"
 	"github.com/redblacktree/fastflow/internal/config"
 	"github.com/redblacktree/fastflow/internal/monitor"
 	"github.com/redblacktree/fastflow/internal/output"
@@ -20,7 +21,6 @@ import (
 	"github.com/redblacktree/fastflow/internal/state"
 	"github.com/redblacktree/fastflow/internal/templates"
 	"github.com/redblacktree/fastflow/internal/worktree"
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
@@ -97,7 +97,11 @@ Examples:
   fastflow run --ticket ENG-1240 --stage plan
 
   # Force run even if another run is active (recovery)
-  fastflow run --ticket ENG-1241 --force`,
+  fastflow run --ticket ENG-1241 --force
+
+  # Fire a shell command on completion (success, failure, or signal)
+  fastflow run --ticket ENG-1242 --goal "..." \
+    --on-complete 'echo "$FASTFLOW_TICKET finished: $FASTFLOW_STATUS" | mailx -s fastflow ops@example.com'`,
 	RunE: runRun,
 }
 
@@ -204,14 +208,14 @@ var (
 	flagCleanPrefix string
 	flagCleanForce  bool
 	flagNoWorktree  bool
-	flagNoFetch      bool
-	flagVerbose      bool
-	flagLogFile      string
-	flagNoColor      bool
-	flagRunForce     bool
-	flagOnComplete   string
-	flagBackground   bool
-	flagMonitorAddr  string
+	flagNoFetch     bool
+	flagVerbose     bool
+	flagLogFile     string
+	flagNoColor     bool
+	flagRunForce    bool
+	flagOnComplete  string
+	flagBackground  bool
+	flagMonitorAddr string
 )
 
 func init() {
@@ -242,7 +246,10 @@ func init() {
 	runCmd.Flags().BoolVar(&flagNoFetch, "no-fetch", false, "Skip fetching main branch from origin before creating worktree")
 	runCmd.Flags().BoolVar(&flagVerbose, "verbose", false, "Show tool activity during stage execution")
 	runCmd.Flags().BoolVar(&flagRunForce, "force", false, "Bypass duplicate run detection (use for recovery)")
-	runCmd.Flags().StringVar(&flagOnComplete, "on-complete", "", "Shell command to run after completion (receives FASTFLOW_* env vars)")
+	runCmd.Flags().StringVar(&flagOnComplete, "on-complete", "",
+		"Shell command to run after the pipeline exits. Receives FASTFLOW_TICKET, "+
+			"FASTFLOW_STATUS, FASTFLOW_WORKTREE, FASTFLOW_RUN_DIR, FASTFLOW_ERROR, "+
+			"FASTFLOW_WORKFLOW. Times out after 5 minutes. See README for examples.")
 	runCmd.Flags().BoolVar(&flagBackground, "background", false, "Run in background (detach from terminal)")
 
 	// Only ticket is required - goal can come from multiple sources

--- a/internal/runner/oncomplete_test.go
+++ b/internal/runner/oncomplete_test.go
@@ -4,7 +4,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/redblacktree/fastflow/internal/state"
 )
@@ -15,6 +17,7 @@ func TestExecuteOnComplete_Success(t *testing.T) {
 
 	ctx := &RunContext{
 		WorkDir: "/tmp/test-worktree",
+		RunDir:  "/tmp/test-rundir",
 	}
 	pState := &state.PipelineState{
 		Ticket:     "TEST-001",
@@ -35,6 +38,7 @@ func TestExecuteOnComplete_Success(t *testing.T) {
 		"FASTFLOW_TICKET=":   "TEST-001",
 		"FASTFLOW_STATUS=":   "complete",
 		"FASTFLOW_WORKTREE=": "/tmp/test-worktree",
+		"FASTFLOW_RUN_DIR=":  "/tmp/test-rundir",
 		"FASTFLOW_WORKFLOW=": "full",
 	}
 	for prefix, want := range checks {
@@ -103,4 +107,57 @@ func TestExecuteOnComplete_CommandFailure(t *testing.T) {
 	}
 	// Should not panic or propagate the error
 	executeOnComplete(ctx, pState)
+}
+
+func TestExecuteOnComplete_Timeout(t *testing.T) {
+	orig := onCompleteTimeout
+	onCompleteTimeout = 100 * time.Millisecond
+	defer func() { onCompleteTimeout = orig }()
+
+	ctx := &RunContext{WorkDir: "/tmp"}
+	pState := &state.PipelineState{
+		Ticket:     "TEST-TIMEOUT",
+		Status:     state.StatusComplete,
+		OnComplete: "sleep 5",
+	}
+
+	start := time.Now()
+	executeOnComplete(ctx, pState)
+	elapsed := time.Since(start)
+
+	if elapsed > 2*time.Second {
+		t.Errorf("executeOnComplete did not return within timeout window: %s", elapsed)
+	}
+}
+
+func TestHandleTerminationSignal_FiresOnComplete(t *testing.T) {
+	runDir := t.TempDir()
+	outFile := filepath.Join(runDir, "hook.out")
+
+	ctx := &RunContext{WorkDir: "/tmp/test-wt", RunDir: runDir}
+	pState := state.NewState("full", []string{"plan"}, "TEST-SIG", "/tmp/test-wt")
+	pState.OnComplete = "env | grep FASTFLOW > " + outFile
+	if err := pState.Save(runDir); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	handleTerminationSignal(ctx, pState, syscall.SIGTERM)
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("hook output not written: %v", err)
+	}
+	out := string(data)
+
+	if !strings.Contains(out, "FASTFLOW_STATUS=failed") {
+		t.Errorf("expected FASTFLOW_STATUS=failed, got: %s", out)
+	}
+	if !strings.Contains(out, "FASTFLOW_ERROR=received signal: terminated") {
+		t.Errorf("expected FASTFLOW_ERROR with signal name, got: %s", out)
+	}
+
+	loaded, _ := state.Load(runDir)
+	if loaded == nil || loaded.Status != state.StatusFailed {
+		t.Errorf("expected persisted status=failed, got: %+v", loaded)
+	}
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -12,12 +13,12 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/redblacktree/fastflow/internal/config"
 	"github.com/redblacktree/fastflow/internal/judge"
 	"github.com/redblacktree/fastflow/internal/output"
 	"github.com/redblacktree/fastflow/internal/state"
 	"github.com/redblacktree/fastflow/internal/worktree"
-	"github.com/fatih/color"
 )
 
 const (
@@ -25,15 +26,17 @@ const (
 	maxEvalRetries         = 2
 )
 
+var onCompleteTimeout = 5 * time.Minute
+
 // Runner orchestrates the execution of pipeline stages.
 type Runner struct {
-	Config         *config.Config
-	ConfigPath     string
-	NoReview       bool
-	DryRun         bool
-	Debug          bool
-	Verbose        bool
-	Resume         string // "auto", "true", "false", or "force"
+	Config     *config.Config
+	ConfigPath string
+	NoReview   bool
+	DryRun     bool
+	Debug      bool
+	Verbose    bool
+	Resume     string // "auto", "true", "false", or "force"
 	// MaxResumptions is the maximum number of handoff/resume cycles per stage (default: 3).
 	MaxResumptions int
 	// Interactive controls whether to prompt human for input (true) or auto-answer (false).
@@ -126,9 +129,7 @@ func (r *Runner) Run(ctx *RunContext) error {
 	defer signal.Stop(sigChan)
 	go func() {
 		sig := <-sigChan
-		errMsg := fmt.Sprintf("received signal: %s", sig)
-		pipelineState.SetFinalStatus(ctx.RunDir, state.StatusFailed, 1, errMsg) //nolint:errcheck
-		state.RemovePID(ctx.RunDir)
+		handleTerminationSignal(ctx, pipelineState, sig)
 		os.Exit(1)
 	}()
 
@@ -366,9 +367,7 @@ func (r *Runner) RunSingleStage(ctx *RunContext) error {
 	defer signal.Stop(sigChan)
 	go func() {
 		sig := <-sigChan
-		errMsg := fmt.Sprintf("received signal: %s", sig)
-		pipelineState.SetFinalStatus(ctx.RunDir, state.StatusFailed, 1, errMsg) //nolint:errcheck
-		state.RemovePID(ctx.RunDir)
+		handleTerminationSignal(ctx, pipelineState, sig)
 		os.Exit(1)
 	}()
 
@@ -1122,9 +1121,11 @@ Continue with the task based on the human's answer. Proceed with the implementat
 
 // executeOnComplete runs the on-complete shell command with environment variables
 // describing the run result. Errors are logged but do not affect the caller.
+// The command is killed after onCompleteTimeout to prevent hung hooks from
+// wedging a long-lived or background run.
 func executeOnComplete(ctx *RunContext, pState *state.PipelineState) {
-	cmd := pState.OnComplete
-	if cmd == "" {
+	cmdStr := pState.OnComplete
+	if cmdStr == "" {
 		return
 	}
 
@@ -1133,20 +1134,39 @@ func executeOnComplete(ctx *RunContext, pState *state.PipelineState) {
 		"FASTFLOW_TICKET="+pState.Ticket,
 		"FASTFLOW_STATUS="+pState.Status,
 		"FASTFLOW_WORKTREE="+ctx.WorkDir,
+		"FASTFLOW_RUN_DIR="+ctx.RunDir,
 		"FASTFLOW_ERROR="+pState.Error,
 		"FASTFLOW_PR_URL=",
 		"FASTFLOW_WORKFLOW="+pState.Workflow,
 	)
 
-	c := exec.Command("sh", "-c", cmd)
+	execCtx, cancel := context.WithTimeout(context.Background(), onCompleteTimeout)
+	defer cancel()
+
+	c := exec.CommandContext(execCtx, "sh", "-c", cmdStr)
 	c.Env = env
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
 
-	if err := c.Run(); err != nil {
+	err := c.Run()
+	if err != nil {
 		warning := color.New(color.FgYellow).SprintFunc()
+		if execCtx.Err() == context.DeadlineExceeded {
+			output.Printf("    %s on-complete command timed out after %s\n",
+				warning("WARN"), onCompleteTimeout)
+			return
+		}
 		output.Printf("    %s on-complete command failed: %v\n", warning("WARN"), err)
 	}
+}
+
+// handleTerminationSignal writes final state, fires the on-complete hook, and
+// removes the PID file. Called from signal handler goroutines before os.Exit.
+func handleTerminationSignal(ctx *RunContext, pState *state.PipelineState, sig os.Signal) {
+	errMsg := fmt.Sprintf("received signal: %s", sig)
+	pState.SetFinalStatus(ctx.RunDir, state.StatusFailed, 1, errMsg) //nolint:errcheck
+	executeOnComplete(ctx, pState)
+	state.RemovePID(ctx.RunDir)
 }
 
 // truncateForContext truncates output to fit within context limits.


### PR DESCRIPTION
## Summary

- Fires the `--on-complete` hook on **signal-driven termination** (SIGTERM/SIGINT) as well as normal exit, closing the dominant durability gap for long-lived and `--background` runs. Extracts a `handleTerminationSignal` helper used by both `Run()` and `RunSingleStage()` signal goroutines.
- Adds a **5-minute execution budget** to `executeOnComplete` via `exec.CommandContext`, preventing a hung operator hook from wedging a background process indefinitely. Emits a `WARN` on timeout; hook failures never affect fastflow's own exit code.
- Adds **`FASTFLOW_RUN_DIR`** to the hook's environment so operator scripts can locate `goal.md`, `state.json`, and other run artifacts without re-deriving the path from `FASTFLOW_WORKTREE`.
- Documents `--on-complete` fully in `README.md` (env-var table, behavior notes, three worked examples) and adds a usage example to `fastflow run --help`.

## Background

The `--on-complete` flag was shipped in REL-360 (#33). It was functional but had three gaps that prevented operators from relying on it:

1. **SIGTERM bypassed the hook** — both signal handlers in `runner.go` called `os.Exit(1)` directly, which skips deferred functions and therefore the on-complete call. For long-lived `--background` runs killed via SIGTERM this was silent data loss.
2. **No timeout** — `executeOnComplete` used `exec.Command` with no deadline. A curl to a slow endpoint or a blocking script could hang a background fastflow process indefinitely.
3. **Zero documentation** — `README.md` had no mention of `--on-complete`. Q's durable usage notes recommend the flag, but operators reading the repo would never know it exists.

## Test plan

- [x] `go test ./internal/runner/ -run "TestExecuteOnComplete|TestHandleTerminationSignal" -count=1` — all oncomplete tests pass including new timeout and signal tests
- [x] `go build ./...` — build clean
- [ ] Manual: start a `--background` run with `--on-complete 'echo $FASTFLOW_STATUS > /tmp/ff-hook-out'`, send SIGTERM to the daemonized PID, confirm `/tmp/ff-hook-out` contains `failed`
- [ ] Manual: `--on-complete 'sleep 600'` run exits within ~5 min with `WARN on-complete command timed out` message
- [ ] Manual: `fastflow run --help` shows the new `--on-complete` example and updated flag description

🤖 Generated with [Claude Code](https://claude.com/claude-code)