### PR TITLE
feat: stale-handoff reconcile slice — detect & repair parents missing QA/Review children (REL-546)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,35 @@ fastflow uses `orchestrator.json` for workflow configuration. See the included c
 - Setting up checkpoints for human review
 - Custom judge prompts for stage validation
 
+### fastflow reconcile stale-handoff
+
+Detects parent Linear issues that have a `Q HANDOFF / RETEST READY` comment but are missing their QA and Review child lanes. In dry-run mode (default) it prints a fact-backed proposal listing exactly what would be created. With `--apply` it executes the repair exactly once: creates a `QA: <title>` child (assigned to the QA owner), creates a `Review: <title>` child (assigned to the reviewer), moves the parent to `In Review`, copies the canonical handoff boundary onto the QA child, and posts a repair pointer on the parent. Re-running on a post-repair parent is a no-op.
+
+**Required environment variables**
+
+| Variable | Flag override | Description |
+|---|---|---|
+| `LINEAR_API_KEY` | `--linear-token` | Linear personal API token |
+| `LINEAR_TEAM_ID` | `--team` | Linear team ID |
+| `LINEAR_IN_REVIEW_STATE_ID` | `--in-review-state` | Workflow state UUID for "In Review" |
+| `LINEAR_QA_ASSIGNEE_ID` | `--qa-assignee` | Linear user UUID for the QA child |
+| `LINEAR_REVIEW_ASSIGNEE_ID` | `--review-assignee` | Linear user UUID for the Review child |
+
+**Examples**
+
+```bash
+# Dry-run — inspect the proposal without making any changes
+LINEAR_API_KEY=... fastflow reconcile stale-handoff --issue REL-548
+
+# Apply the repair
+LINEAR_API_KEY=... \
+  LINEAR_TEAM_ID=... \
+  LINEAR_IN_REVIEW_STATE_ID=... \
+  LINEAR_QA_ASSIGNEE_ID=... \
+  LINEAR_REVIEW_ASSIGNEE_ID=... \
+  fastflow reconcile stale-handoff --issue REL-548 --apply
+```
+
 ## Acknowledgements
 
 The workflow prompts and orchestration patterns in this project were inspired by [HumanLayer](https://github.com/humanlayer/humanlayer).

--- a/cmd/fastflow/reconcile.go
+++ b/cmd/fastflow/reconcile.go
@@ -17,12 +17,12 @@ import (
 )
 
 var (
-	flagReconcileIssue           string
-	flagReconcileApply           bool
-	flagReconcileLinearToken     string
-	flagReconcileTeamID          string
-	flagReconcileInReviewStateID string
-	flagReconcileQAAssigneeID    string
+	flagReconcileIssue            string
+	flagReconcileApply            bool
+	flagReconcileLinearToken      string
+	flagReconcileTeamID           string
+	flagReconcileInReviewStateID  string
+	flagReconcileQAAssigneeID     string
 	flagReconcileReviewAssigneeID string
 )
 

--- a/cmd/fastflow/reconcile.go
+++ b/cmd/fastflow/reconcile.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/redblacktree/fastflow/internal/linear"
+	"github.com/redblacktree/fastflow/internal/output"
+	"github.com/redblacktree/fastflow/internal/reconcile"
+	"github.com/redblacktree/fastflow/internal/runner"
+	"github.com/spf13/cobra"
+)
+
+var (
+	flagReconcileIssue           string
+	flagReconcileApply           bool
+	flagReconcileLinearToken     string
+	flagReconcileTeamID          string
+	flagReconcileInReviewStateID string
+	flagReconcileQAAssigneeID    string
+	flagReconcileReviewAssigneeID string
+)
+
+var reconcileCmd = &cobra.Command{
+	Use:   "reconcile",
+	Short: "Run reconcile slices that detect and repair workflow gaps",
+	Long:  `Reconcile commands inspect Linear state and propose / apply targeted repairs.`,
+}
+
+var staleHandoffCmd = &cobra.Command{
+	Use:   "stale-handoff",
+	Short: "Detect & repair parents with a Q handoff but missing QA/Review children",
+	Long: `Detect parent Linear issues that have a Q HANDOFF / RETEST READY comment but
+are missing their QA and Review child lanes, then produce a fact-backed proposal
+(dry-run) or execute a safe, idempotent repair (--apply).
+
+Examples:
+  # Dry-run against REL-548 (shows proposal or no-op)
+  fastflow reconcile stale-handoff --issue REL-548
+
+  # Apply the repair
+  LINEAR_API_KEY=... fastflow reconcile stale-handoff --issue REL-548 --apply`,
+	RunE: runReconcileStaleHandoff,
+}
+
+func init() {
+	staleHandoffCmd.Flags().StringVar(&flagReconcileIssue, "issue", "", "Linear issue identifier (e.g. REL-548)")
+	staleHandoffCmd.Flags().BoolVar(&flagReconcileApply, "apply", false, "Execute the repair (default: dry-run)")
+	staleHandoffCmd.Flags().StringVar(&flagReconcileLinearToken, "linear-token", "", "Linear API token (default: $LINEAR_API_KEY)")
+	staleHandoffCmd.Flags().StringVar(&flagReconcileTeamID, "team", "", "Linear team ID (default: $LINEAR_TEAM_ID)")
+	staleHandoffCmd.Flags().StringVar(&flagReconcileInReviewStateID, "in-review-state", "", "Linear workflow state ID for In Review (default: $LINEAR_IN_REVIEW_STATE_ID)")
+	staleHandoffCmd.Flags().StringVar(&flagReconcileQAAssigneeID, "qa-assignee", "", "Linear user ID for QA child (default: $LINEAR_QA_ASSIGNEE_ID)")
+	staleHandoffCmd.Flags().StringVar(&flagReconcileReviewAssigneeID, "review-assignee", "", "Linear user ID for Review child (default: $LINEAR_REVIEW_ASSIGNEE_ID)")
+	_ = staleHandoffCmd.MarkFlagRequired("issue")
+
+	reconcileCmd.AddCommand(staleHandoffCmd)
+	rootCmd.AddCommand(reconcileCmd)
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func runReconcileStaleHandoff(cmd *cobra.Command, args []string) error {
+	errColor := color.New(color.FgRed).SprintFunc()
+
+	token := firstNonEmpty(flagReconcileLinearToken, os.Getenv("LINEAR_API_KEY"))
+	if token == "" {
+		return fmt.Errorf("%s LINEAR_API_KEY environment variable or --linear-token flag is required",
+			errColor("ERROR"))
+	}
+
+	cfg := reconcile.Config{
+		TeamID:            firstNonEmpty(flagReconcileTeamID, os.Getenv("LINEAR_TEAM_ID")),
+		InReviewStateID:   firstNonEmpty(flagReconcileInReviewStateID, os.Getenv("LINEAR_IN_REVIEW_STATE_ID")),
+		InReviewStateName: "In Review",
+		QAAssigneeID:      firstNonEmpty(flagReconcileQAAssigneeID, os.Getenv("LINEAR_QA_ASSIGNEE_ID")),
+		ReviewAssigneeID:  firstNonEmpty(flagReconcileReviewAssigneeID, os.Getenv("LINEAR_REVIEW_ASSIGNEE_ID")),
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get working directory: %w", err)
+	}
+	runDir := runner.GetRunDir(cwd, flagReconcileIssue)
+
+	client := linear.New(token)
+	return runReconcileStaleHandoffWith(flagReconcileIssue, flagReconcileApply, cfg, client, runDir)
+}
+
+// runReconcileStaleHandoffWith is the testable handler. Tests inject a fake client
+// and a temp runDir; the cobra handler builds the real client and delegates here.
+func runReconcileStaleHandoffWith(
+	issue string,
+	apply bool,
+	cfg reconcile.Config,
+	client reconcile.Mutator,
+	runDir string,
+) error {
+	errColor := color.New(color.FgRed).SprintFunc()
+	info := color.New(color.FgCyan).SprintFunc()
+	successColor := color.New(color.FgGreen).SprintFunc()
+
+	iss, err := client.GetIssueWithChildren(issue)
+	if err != nil {
+		return fmt.Errorf("%s failed to fetch issue %s: %w", errColor("ERROR"), issue, err)
+	}
+
+	facts := reconcile.Detect(iss)
+	proposal, verdict := reconcile.Propose(facts, cfg)
+
+	if verdict.Blocked {
+		output.Printf("%s No-op: %s\n", info(">>>"), verdict.Reason)
+		return nil
+	}
+
+	printProposal(proposal)
+
+	if !apply {
+		output.Printf("[run with --apply to execute]\n")
+		return nil
+	}
+
+	if err := os.MkdirAll(runDir, 0755); err != nil {
+		return fmt.Errorf("%s failed to create run dir: %w", errColor("ERROR"), err)
+	}
+	recordPath := filepath.Join(runDir, "reconcile-"+issue+".json")
+
+	persist := func(r *reconcile.RepairRecord) error {
+		data, jerr := json.MarshalIndent(r, "", "  ")
+		if jerr != nil {
+			return jerr
+		}
+		return os.WriteFile(recordPath, data, 0644)
+	}
+
+	record, err := reconcile.Apply(client, issue, cfg, persist)
+	var alreadyApplied *reconcile.ErrAlreadyApplied
+	if errors.As(err, &alreadyApplied) {
+		output.Printf("%s No-op: %s\n", info(">>>"), alreadyApplied.Reason)
+		return nil
+	}
+	if err != nil {
+		output.Printf("%s Apply failed: %v\n", errColor("ERROR"), err)
+		if recordPath != "" {
+			output.Printf("    Partial record: %s\n", recordPath)
+		}
+		return err
+	}
+
+	output.Printf("%s Repair applied successfully\n", successColor("SUCCESS"))
+	output.Printf("  QA child:       %s\n", record.QAChildIdentifier)
+	output.Printf("  Review child:   %s\n", record.ReviewChildIdentifier)
+	output.Printf("  Repair pointer: %s\n", record.RepairPointerID)
+	return nil
+}
+
+func printProposal(p *reconcile.Proposal) {
+	output.Printf("PROPOSAL: %s — stale handoff detected\n", p.ParentIdentifier)
+	output.Printf("  %-21s  %s\n", "parent id", p.ParentID)
+	output.Printf("  %-21s  %s\n", "parent state", p.ParentStateName)
+	output.Printf("  %-21s  %s\n", "source comment id", p.SourceCommentID)
+	output.Printf("  %-21s  %s\n", "missing lanes", strings.Join(p.MissingLanes, ", "))
+	output.Printf("  %-21s  \"%s\" → assignee %s\n", "intended QA child", p.IntendedQATitle, p.IntendedQAAssigneeID)
+	output.Printf("  %-21s  \"%s\" → assignee %s\n", "intended Review child", p.IntendedReviewTitle, p.IntendedReviewAssigneeID)
+	output.Printf("  %-21s  %s → %s\n", "parent state change", p.ParentStateName, p.IntendedParentStateName)
+
+	prURL := p.DerivedPRURL
+	if prURL == "" {
+		prURL = "(none detected)"
+	}
+	branch := p.DerivedBranch
+	if branch == "" {
+		branch = "(none detected)"
+	}
+	output.Printf("  %-21s  %s\n", "derived PR", prURL)
+	output.Printf("  %-21s  %s\n", "derived branch", branch)
+	output.Printf("\n")
+	output.Printf("Boundary (verbatim, will be copied to QA child):\n")
+	for _, line := range strings.Split(p.Boundary, "\n") {
+		if line == "" {
+			output.Printf("  |\n")
+		} else {
+			output.Printf("  | %s\n", line)
+		}
+	}
+	output.Printf("\n")
+}

--- a/cmd/fastflow/reconcile.go
+++ b/cmd/fastflow/reconcile.go
@@ -157,7 +157,11 @@ func runReconcileStaleHandoffWith(
 	if err != nil {
 		output.Printf("%s Apply failed: %v\n", errColor("ERROR"), err)
 		if recordPath != "" {
-			output.Printf("    Partial record: %s\n", recordPath)
+			if _, statErr := os.Stat(recordPath); statErr == nil {
+				output.Printf("    Partial record: %s\n", recordPath)
+			} else {
+				output.Printf("    Audit record unavailable: %s\n", recordPath)
+			}
 		}
 		return err
 	}

--- a/cmd/fastflow/reconcile.go
+++ b/cmd/fastflow/reconcile.go
@@ -131,6 +131,10 @@ func runReconcileStaleHandoffWith(
 		return nil
 	}
 
+	if err := validateStaleHandoffApplyConfig(cfg); err != nil {
+		return fmt.Errorf("%s %w", errColor("ERROR"), err)
+	}
+
 	if err := os.MkdirAll(runDir, 0755); err != nil {
 		return fmt.Errorf("%s failed to create run dir: %w", errColor("ERROR"), err)
 	}
@@ -162,6 +166,26 @@ func runReconcileStaleHandoffWith(
 	output.Printf("  QA child:       %s\n", record.QAChildIdentifier)
 	output.Printf("  Review child:   %s\n", record.ReviewChildIdentifier)
 	output.Printf("  Repair pointer: %s\n", record.RepairPointerID)
+	return nil
+}
+
+func validateStaleHandoffApplyConfig(cfg reconcile.Config) error {
+	missing := []string{}
+	if strings.TrimSpace(cfg.TeamID) == "" {
+		missing = append(missing, "LINEAR_TEAM_ID/--team")
+	}
+	if strings.TrimSpace(cfg.InReviewStateID) == "" {
+		missing = append(missing, "LINEAR_IN_REVIEW_STATE_ID/--in-review-state")
+	}
+	if strings.TrimSpace(cfg.QAAssigneeID) == "" {
+		missing = append(missing, "LINEAR_QA_ASSIGNEE_ID/--qa-assignee")
+	}
+	if strings.TrimSpace(cfg.ReviewAssigneeID) == "" {
+		missing = append(missing, "LINEAR_REVIEW_ASSIGNEE_ID/--review-assignee")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("apply requires all Linear repair config before mutations; missing: %s", strings.Join(missing, ", "))
+	}
 	return nil
 }
 

--- a/cmd/fastflow/reconcile_test.go
+++ b/cmd/fastflow/reconcile_test.go
@@ -179,6 +179,68 @@ func TestRunReconcileStaleHandoff_apply_REL548_pre_writesRecordFile(t *testing.T
 	}
 }
 
+func TestRunReconcileStaleHandoff_applyMissingConfigRefusesBeforeMutation(t *testing.T) {
+	_, cleanup := captureOutput(t)
+	defer cleanup()
+
+	tests := []struct {
+		name    string
+		mutate  func(*reconcile.Config)
+		wantErr string
+	}{
+		{
+			name: "missing team",
+			mutate: func(cfg *reconcile.Config) {
+				cfg.TeamID = ""
+			},
+			wantErr: "LINEAR_TEAM_ID/--team",
+		},
+		{
+			name: "missing in review state",
+			mutate: func(cfg *reconcile.Config) {
+				cfg.InReviewStateID = ""
+			},
+			wantErr: "LINEAR_IN_REVIEW_STATE_ID/--in-review-state",
+		},
+		{
+			name: "missing qa assignee",
+			mutate: func(cfg *reconcile.Config) {
+				cfg.QAAssigneeID = ""
+			},
+			wantErr: "LINEAR_QA_ASSIGNEE_ID/--qa-assignee",
+		},
+		{
+			name: "missing review assignee",
+			mutate: func(cfg *reconcile.Config) {
+				cfg.ReviewAssigneeID = ""
+			},
+			wantErr: "LINEAR_REVIEW_ASSIGNEE_ID/--review-assignee",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := testReconcileCfg
+			tt.mutate(&cfg)
+			client := &fakeClient{issue: makeREL548Pre()}
+
+			err := runReconcileStaleHandoffWith("REL-548", true, cfg, client, t.TempDir())
+			if err == nil {
+				t.Fatal("expected missing config error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error %q does not mention %q", err.Error(), tt.wantErr)
+			}
+			if client.createCount != 0 {
+				t.Fatalf("expected no issue mutations, got %d CreateIssue calls", client.createCount)
+			}
+			if len(client.comments) != 0 {
+				t.Fatalf("expected no comment mutations, got %d CreateComment calls", len(client.comments))
+			}
+		})
+	}
+}
+
 func TestRunReconcileStaleHandoff_apply_post_repair_exits_zero_with_no_op(t *testing.T) {
 	buf, cleanup := captureOutput(t)
 	defer cleanup()

--- a/cmd/fastflow/reconcile_test.go
+++ b/cmd/fastflow/reconcile_test.go
@@ -179,6 +179,45 @@ func TestRunReconcileStaleHandoff_apply_REL548_pre_writesRecordFile(t *testing.T
 	}
 }
 
+func TestRunReconcileStaleHandoff_applyPersistFailureAfterMutationReturnsError(t *testing.T) {
+	buf, cleanup := captureOutput(t)
+	defer cleanup()
+
+	runDir := t.TempDir()
+	if err := os.Chmod(runDir, 0500); err != nil {
+		t.Fatalf("chmod runDir: %v", err)
+	}
+	defer func() {
+		_ = os.Chmod(runDir, 0700)
+	}()
+
+	client := &fakeClient{issue: makeREL548Pre()}
+	err := runReconcileStaleHandoffWith("REL-548", true, testReconcileCfg, client, runDir)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "persist repair record after create QA child") {
+		t.Fatalf("error %q does not mention create QA child persist failure", err.Error())
+	}
+	if client.createCount != 1 {
+		t.Fatalf("expected 1 CreateIssue before persist failure, got %d", client.createCount)
+	}
+	if len(client.comments) != 0 {
+		t.Fatalf("expected no comments after early persist failure, got %d", len(client.comments))
+	}
+
+	got := buf.String()
+	if !strings.Contains(got, "Apply failed:") {
+		t.Fatalf("output %q does not include apply failure", got)
+	}
+	if !strings.Contains(got, "Audit record unavailable:") {
+		t.Fatalf("output %q does not report missing audit record", got)
+	}
+	if strings.Contains(got, "Repair applied successfully") {
+		t.Fatalf("output %q should not report success", got)
+	}
+}
+
 func TestRunReconcileStaleHandoff_applyMissingConfigRefusesBeforeMutation(t *testing.T) {
 	_, cleanup := captureOutput(t)
 	defer cleanup()

--- a/cmd/fastflow/reconcile_test.go
+++ b/cmd/fastflow/reconcile_test.go
@@ -1,0 +1,258 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/fatih/color"
+	"github.com/redblacktree/fastflow/internal/linear"
+	"github.com/redblacktree/fastflow/internal/output"
+	"github.com/redblacktree/fastflow/internal/reconcile"
+)
+
+// fakeClient implements reconcile.Mutator using pre-set issue data.
+type fakeClient struct {
+	issue   *linear.Issue
+	failGet bool
+	// mutation results
+	createCount   int
+	createdIssues []*linear.Issue
+	comments      []*linear.Comment
+}
+
+func (f *fakeClient) GetIssueWithChildren(id string) (*linear.Issue, error) {
+	if f.failGet {
+		return nil, errors.New("simulated get failure")
+	}
+	return f.issue, nil
+}
+
+func (f *fakeClient) CreateIssue(in linear.CreateIssueInput) (*linear.Issue, error) {
+	f.createCount++
+	iss := &linear.Issue{ID: "stub-id-" + in.Title[:3], Identifier: "STUB-20" + string(rune('0'+f.createCount)), Title: in.Title}
+	f.createdIssues = append(f.createdIssues, iss)
+	return iss, nil
+}
+
+func (f *fakeClient) UpdateIssueState(issueID, stateID string) error { return nil }
+
+func (f *fakeClient) CreateComment(issueID, body string) (*linear.Comment, error) {
+	c := &linear.Comment{ID: "stub-cmt-" + issueID, Body: body}
+	f.comments = append(f.comments, c)
+	return c, nil
+}
+
+// captureOutput temporarily redirects output.Writer and disables colors.
+// Returns the captured bytes and a cleanup function.
+func captureOutput(t *testing.T) (*bytes.Buffer, func()) {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	prev := output.Writer
+	prevNoColor := color.NoColor
+	output.Writer = buf
+	color.NoColor = true
+	return buf, func() {
+		output.Writer = prev
+		color.NoColor = prevNoColor
+	}
+}
+
+func makeREL548Pre() *linear.Issue {
+	return &linear.Issue{
+		ID:         "aaa00548-0000-0000-0000-000000000000",
+		Identifier: "REL-548",
+		Title:      "Add --on-complete hook support for pipeline runs",
+		State:      linear.WorkflowState{ID: "state-in-progress-id", Name: "In Progress", Type: "started"},
+		Comments: []linear.Comment{
+			{
+				ID:        "556160da",
+				Body:      "Q HANDOFF / RETEST READY\n\nBranch: REL-548\nPR: https://github.com/redblacktree/fastflow/pull/36\n\nImplementation complete. --on-complete flag added and tested.",
+				CreatedAt: "2026-04-28T14:00:00.000Z",
+			},
+		},
+	}
+}
+
+func makeREL548Post() *linear.Issue {
+	return &linear.Issue{
+		ID:         "aaa00548-0000-0000-0000-000000000000",
+		Identifier: "REL-548",
+		Title:      "Add --on-complete hook support for pipeline runs",
+		State:      linear.WorkflowState{ID: "state-in-review-id", Name: "In Review", Type: "started"},
+		Children: []linear.Issue{
+			{ID: "aaa00558-0000-0000-0000-000000000000", Identifier: "REL-558", Title: "QA: Add --on-complete hook support for pipeline runs"},
+			{ID: "aaa00559-0000-0000-0000-000000000000", Identifier: "REL-559", Title: "Review: Add --on-complete hook support for pipeline runs"},
+		},
+		Comments: []linear.Comment{
+			{
+				ID:   "556160da",
+				Body: "Q HANDOFF / RETEST READY\n\nBranch: REL-548\nPR: https://github.com/redblacktree/fastflow/pull/36\n\nImplementation complete. --on-complete flag added and tested.",
+			},
+			{
+				ID:   "repair-ptr-548",
+				Body: "[fastflow-reconcile] stale-handoff repair applied\n- QA child: REL-558\n- Review child: REL-559\n- Source comment id: 556160da\n- Tool: fastflow reconcile stale-handoff (REL-546)",
+			},
+		},
+	}
+}
+
+var testReconcileCfg = reconcile.Config{
+	TeamID:            "test-team-id",
+	InReviewStateID:   "state-in-review-id",
+	InReviewStateName: "In Review",
+	QAAssigneeID:      "test-qa-assignee-id",
+	ReviewAssigneeID:  "test-review-assignee-id",
+}
+
+func TestRunReconcileStaleHandoff_dryRun_REL548_pre_printsExpectedProposal(t *testing.T) {
+	buf, cleanup := captureOutput(t)
+	defer cleanup()
+
+	client := &fakeClient{issue: makeREL548Pre()}
+	runDir := t.TempDir()
+
+	if err := runReconcileStaleHandoffWith("REL-548", false, testReconcileCfg, client, runDir); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := buf.String()
+	goldenPath := filepath.Join("testdata", "proposal_REL-548_pre.txt")
+	wantBytes, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("read golden file: %v", err)
+	}
+	want := string(wantBytes)
+
+	if got != want {
+		t.Errorf("output mismatch\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+func TestRunReconcileStaleHandoff_dryRun_REL548_post_prints_no_op(t *testing.T) {
+	buf, cleanup := captureOutput(t)
+	defer cleanup()
+
+	client := &fakeClient{issue: makeREL548Post()}
+	if err := runReconcileStaleHandoffWith("REL-548", false, testReconcileCfg, client, t.TempDir()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := buf.String()
+	if !strings.HasPrefix(got, ">>> No-op:") {
+		t.Errorf("output should start with '>>> No-op:', got: %q", got)
+	}
+}
+
+func TestRunReconcileStaleHandoff_apply_REL548_pre_writesRecordFile(t *testing.T) {
+	_, cleanup := captureOutput(t)
+	defer cleanup()
+
+	runDir := t.TempDir()
+	client := &fakeClient{issue: makeREL548Pre()}
+
+	if err := runReconcileStaleHandoffWith("REL-548", true, testReconcileCfg, client, runDir); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	recordPath := filepath.Join(runDir, "reconcile-REL-548.json")
+	data, err := os.ReadFile(recordPath)
+	if err != nil {
+		t.Fatalf("record file not created: %v", err)
+	}
+	var record reconcile.RepairRecord
+	if err := json.Unmarshal(data, &record); err != nil {
+		t.Fatalf("record JSON invalid: %v", err)
+	}
+	if record.QAChildIdentifier == "" {
+		t.Error("QAChildIdentifier is empty in record")
+	}
+	if record.ReviewChildIdentifier == "" {
+		t.Error("ReviewChildIdentifier is empty in record")
+	}
+	if record.RepairPointerID == "" {
+		t.Error("RepairPointerID is empty in record")
+	}
+}
+
+func TestRunReconcileStaleHandoff_apply_post_repair_exits_zero_with_no_op(t *testing.T) {
+	buf, cleanup := captureOutput(t)
+	defer cleanup()
+
+	client := &fakeClient{issue: makeREL548Post()}
+	err := runReconcileStaleHandoffWith("REL-548", true, testReconcileCfg, client, t.TempDir())
+	if err != nil {
+		t.Fatalf("expected nil error (ErrAlreadyApplied → no-op), got %v", err)
+	}
+	got := buf.String()
+	if !strings.HasPrefix(got, ">>> No-op:") {
+		t.Errorf("output should start with '>>> No-op:', got: %q", got)
+	}
+}
+
+func TestRunReconcileStaleHandoff_missing_LINEAR_API_KEY_returns_error(t *testing.T) {
+	// Save and restore env + flag
+	prevToken := flagReconcileLinearToken
+	prevEnv := os.Getenv("LINEAR_API_KEY")
+	flagReconcileLinearToken = ""
+	os.Unsetenv("LINEAR_API_KEY")
+	defer func() {
+		flagReconcileLinearToken = prevToken
+		if prevEnv != "" {
+			os.Setenv("LINEAR_API_KEY", prevEnv)
+		}
+	}()
+
+	// Also ensure --issue is set so cobra flag validation doesn't interfere
+	prevIssue := flagReconcileIssue
+	flagReconcileIssue = "REL-548"
+	defer func() { flagReconcileIssue = prevIssue }()
+
+	err := runReconcileStaleHandoff(staleHandoffCmd, nil)
+	if err == nil {
+		t.Fatal("expected error for missing LINEAR_API_KEY, got nil")
+	}
+	if !strings.Contains(err.Error(), "LINEAR_API_KEY") {
+		t.Errorf("error %q does not mention LINEAR_API_KEY", err.Error())
+	}
+}
+
+// Test that the proposal output for REL-549 matches its golden file.
+func TestRunReconcileStaleHandoff_dryRun_REL549_pre_printsExpectedProposal(t *testing.T) {
+	buf, cleanup := captureOutput(t)
+	defer cleanup()
+
+	client := &fakeClient{issue: &linear.Issue{
+		ID:         "aaa00549-0000-0000-0000-000000000000",
+		Identifier: "REL-549",
+		Title:      "Implement fastflow monitor web dashboard",
+		State:      linear.WorkflowState{ID: "state-in-progress-id", Name: "In Progress", Type: "started"},
+		Comments: []linear.Comment{
+			{
+				ID:        "e0a0b191",
+				Body:      "Q HANDOFF / RETEST READY\n\nBranch: REL-549\nPR: https://github.com/redblacktree/fastflow/pull/41\n\nMonitor command wired and documented. Dashboard functional.",
+				CreatedAt: "2026-04-29T10:00:00.000Z",
+			},
+		},
+	}}
+
+	if err := runReconcileStaleHandoffWith("REL-549", false, testReconcileCfg, client, t.TempDir()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := buf.String()
+	wantBytes, err := os.ReadFile(filepath.Join("testdata", "proposal_REL-549_pre.txt"))
+	if err != nil {
+		t.Fatalf("read golden file: %v", err)
+	}
+	if got != string(wantBytes) {
+		t.Errorf("output mismatch for REL-549\n--- got ---\n%s\n--- want ---\n%s", got, string(wantBytes))
+	}
+}
+
+// Ensure output.Writer is compatible with io.Writer (compile-time check).
+var _ io.Writer = output.Writer

--- a/cmd/fastflow/testdata/proposal_REL-548_pre.txt
+++ b/cmd/fastflow/testdata/proposal_REL-548_pre.txt
@@ -1,0 +1,20 @@
+PROPOSAL: REL-548 — stale handoff detected
+  parent id              aaa00548-0000-0000-0000-000000000000
+  parent state           In Progress
+  source comment id      556160da
+  missing lanes          QA, Review
+  intended QA child      "QA: Add --on-complete hook support for pipeline runs" → assignee test-qa-assignee-id
+  intended Review child  "Review: Add --on-complete hook support for pipeline runs" → assignee test-review-assignee-id
+  parent state change    In Progress → In Review
+  derived PR             https://github.com/redblacktree/fastflow/pull/36
+  derived branch         REL-548
+
+Boundary (verbatim, will be copied to QA child):
+  | Q HANDOFF / RETEST READY
+  |
+  | Branch: REL-548
+  | PR: https://github.com/redblacktree/fastflow/pull/36
+  |
+  | Implementation complete. --on-complete flag added and tested.
+
+[run with --apply to execute]

--- a/cmd/fastflow/testdata/proposal_REL-549_pre.txt
+++ b/cmd/fastflow/testdata/proposal_REL-549_pre.txt
@@ -1,0 +1,20 @@
+PROPOSAL: REL-549 — stale handoff detected
+  parent id              aaa00549-0000-0000-0000-000000000000
+  parent state           In Progress
+  source comment id      e0a0b191
+  missing lanes          QA, Review
+  intended QA child      "QA: Implement fastflow monitor web dashboard" → assignee test-qa-assignee-id
+  intended Review child  "Review: Implement fastflow monitor web dashboard" → assignee test-review-assignee-id
+  parent state change    In Progress → In Review
+  derived PR             https://github.com/redblacktree/fastflow/pull/41
+  derived branch         REL-549
+
+Boundary (verbatim, will be copied to QA child):
+  | Q HANDOFF / RETEST READY
+  |
+  | Branch: REL-549
+  | PR: https://github.com/redblacktree/fastflow/pull/41
+  |
+  | Monitor command wired and documented. Dashboard functional.
+
+[run with --apply to execute]

--- a/internal/linear/client.go
+++ b/internal/linear/client.go
@@ -1,0 +1,299 @@
+package linear
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const defaultEndpoint = "https://api.linear.app/graphql"
+
+type httpDoer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+// Client is a minimal Linear GraphQL client.
+type Client struct {
+	Endpoint string
+	Token    string
+	HTTP     httpDoer
+}
+
+// Issue represents a Linear issue.
+type Issue struct {
+	ID         string        `json:"id"`
+	Identifier string        `json:"identifier"`
+	Title      string        `json:"title"`
+	State      WorkflowState `json:"state"`
+	Parent     *Issue        `json:"parent,omitempty"`
+	Children   []Issue       `json:"-"`
+	Comments   []Comment     `json:"-"`
+	URL        string        `json:"url,omitempty"`
+}
+
+// Comment represents a Linear comment.
+type Comment struct {
+	ID        string `json:"id"`
+	Body      string `json:"body"`
+	User      *User  `json:"user,omitempty"`
+	CreatedAt string `json:"createdAt,omitempty"`
+}
+
+// User represents a Linear user.
+type User struct {
+	ID          string `json:"id"`
+	Name        string `json:"name,omitempty"`
+	DisplayName string `json:"displayName,omitempty"`
+}
+
+// WorkflowState represents a Linear workflow state.
+type WorkflowState struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+// CreateIssueInput holds the inputs for creating a new issue.
+type CreateIssueInput struct {
+	TeamID      string
+	Title       string
+	AssigneeID  string
+	ParentID    string
+	Description string
+}
+
+// New creates a Client with the Linear default endpoint and http.DefaultClient.
+func New(token string) *Client {
+	return &Client{
+		Endpoint: defaultEndpoint,
+		Token:    token,
+		HTTP:     http.DefaultClient,
+	}
+}
+
+// GraphQL query/mutation constants.
+const getIssueWithChildrenQuery = `
+query GetIssueWithChildren($id: String!) {
+  issue(id: $id) {
+    id identifier title url
+    state { id name type }
+    parent { id identifier }
+    children(first: 50) { nodes { id identifier title state { id name type } } }
+    comments(first: 100) { nodes { id body createdAt user { id name displayName } } }
+  }
+}`
+
+const createIssueMutation = `
+mutation CreateIssue($input: IssueCreateInput!) {
+  issueCreate(input: $input) {
+    success
+    issue { id identifier title }
+  }
+}`
+
+const updateIssueStateMutation = `
+mutation UpdateIssueState($id: String!, $stateId: String!) {
+  issueUpdate(id: $id, input: { stateId: $stateId }) {
+    success
+  }
+}`
+
+const createCommentMutation = `
+mutation CreateComment($id: String!, $body: String!) {
+  commentCreate(input: { issueId: $id, body: $body }) {
+    success
+    comment { id body createdAt }
+  }
+}`
+
+// doGraphQL posts a GraphQL request and unmarshals the response data into out.
+func (c *Client) doGraphQL(query string, vars map[string]interface{}, out interface{}) error {
+	payload, err := json.Marshal(map[string]interface{}{
+		"query":     query,
+		"variables": vars,
+	})
+	if err != nil {
+		return fmt.Errorf("linear: marshal request: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, c.Endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("linear: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", c.Token)
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return fmt.Errorf("linear: http: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("linear: read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("linear: http %d: %s", resp.StatusCode, string(body))
+	}
+
+	var errCheck struct {
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if jsonErr := json.Unmarshal(body, &errCheck); jsonErr == nil && len(errCheck.Errors) > 0 {
+		return fmt.Errorf("linear: graphql error: %s", errCheck.Errors[0].Message)
+	}
+
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("linear: unmarshal response: %w", err)
+	}
+	return nil
+}
+
+// Internal types that mirror the GraphQL response shape.
+
+type gqlIssue struct {
+	ID         string        `json:"id"`
+	Identifier string        `json:"identifier"`
+	Title      string        `json:"title"`
+	URL        string        `json:"url"`
+	State      WorkflowState `json:"state"`
+	Parent     *struct {
+		ID         string `json:"id"`
+		Identifier string `json:"identifier"`
+	} `json:"parent"`
+	Children struct {
+		Nodes []gqlIssue `json:"nodes"`
+	} `json:"children"`
+	Comments struct {
+		Nodes []Comment `json:"nodes"`
+	} `json:"comments"`
+}
+
+func (g gqlIssue) toIssue() *Issue {
+	iss := &Issue{
+		ID:         g.ID,
+		Identifier: g.Identifier,
+		Title:      g.Title,
+		URL:        g.URL,
+		State:      g.State,
+		Comments:   g.Comments.Nodes,
+	}
+	if g.Parent != nil {
+		iss.Parent = &Issue{
+			ID:         g.Parent.ID,
+			Identifier: g.Parent.Identifier,
+		}
+	}
+	for _, child := range g.Children.Nodes {
+		iss.Children = append(iss.Children, *child.toIssue())
+	}
+	return iss
+}
+
+// GetIssueWithChildren fetches an issue with its children and comments.
+// identifier may be either a Linear UUID or a human identifier like "REL-548".
+func (c *Client) GetIssueWithChildren(identifier string) (*Issue, error) {
+	var resp struct {
+		Data struct {
+			Issue gqlIssue `json:"issue"`
+		} `json:"data"`
+	}
+	if err := c.doGraphQL(getIssueWithChildrenQuery, map[string]interface{}{"id": identifier}, &resp); err != nil {
+		return nil, err
+	}
+	if resp.Data.Issue.ID == "" {
+		return nil, fmt.Errorf("linear: issue %q not found", identifier)
+	}
+	return resp.Data.Issue.toIssue(), nil
+}
+
+// CreateIssue creates a new Linear issue.
+func (c *Client) CreateIssue(in CreateIssueInput) (*Issue, error) {
+	input := map[string]interface{}{
+		"teamId": in.TeamID,
+		"title":  in.Title,
+	}
+	if in.AssigneeID != "" {
+		input["assigneeId"] = in.AssigneeID
+	}
+	if in.ParentID != "" {
+		input["parentId"] = in.ParentID
+	}
+	if in.Description != "" {
+		input["description"] = in.Description
+	}
+
+	var resp struct {
+		Data struct {
+			IssueCreate struct {
+				Success bool `json:"success"`
+				Issue   struct {
+					ID         string `json:"id"`
+					Identifier string `json:"identifier"`
+					Title      string `json:"title"`
+				} `json:"issue"`
+			} `json:"issueCreate"`
+		} `json:"data"`
+	}
+	if err := c.doGraphQL(createIssueMutation, map[string]interface{}{"input": input}, &resp); err != nil {
+		return nil, err
+	}
+	if !resp.Data.IssueCreate.Success {
+		return nil, fmt.Errorf("linear: issueCreate returned success=false")
+	}
+	iss := resp.Data.IssueCreate.Issue
+	return &Issue{ID: iss.ID, Identifier: iss.Identifier, Title: iss.Title}, nil
+}
+
+// UpdateIssueState moves an issue to a new workflow state.
+func (c *Client) UpdateIssueState(issueID, stateID string) error {
+	var resp struct {
+		Data struct {
+			IssueUpdate struct {
+				Success bool `json:"success"`
+			} `json:"issueUpdate"`
+		} `json:"data"`
+	}
+	if err := c.doGraphQL(updateIssueStateMutation, map[string]interface{}{
+		"id":      issueID,
+		"stateId": stateID,
+	}, &resp); err != nil {
+		return err
+	}
+	if !resp.Data.IssueUpdate.Success {
+		return fmt.Errorf("linear: issueUpdate returned success=false")
+	}
+	return nil
+}
+
+// CreateComment posts a comment on an issue.
+func (c *Client) CreateComment(issueID, body string) (*Comment, error) {
+	var resp struct {
+		Data struct {
+			CommentCreate struct {
+				Success bool    `json:"success"`
+				Comment Comment `json:"comment"`
+			} `json:"commentCreate"`
+		} `json:"data"`
+	}
+	if err := c.doGraphQL(createCommentMutation, map[string]interface{}{
+		"id":   issueID,
+		"body": body,
+	}, &resp); err != nil {
+		return nil, err
+	}
+	if !resp.Data.CommentCreate.Success {
+		return nil, fmt.Errorf("linear: commentCreate returned success=false")
+	}
+	result := resp.Data.CommentCreate.Comment
+	return &result, nil
+}

--- a/internal/linear/client.go
+++ b/internal/linear/client.go
@@ -80,8 +80,34 @@ query GetIssueWithChildren($id: String!) {
     id identifier title url
     state { id name type }
     parent { id identifier }
-    children(first: 50) { nodes { id identifier title state { id name type } } }
-    comments(first: 100) { nodes { id body createdAt user { id name displayName } } }
+    children(first: 50) {
+      pageInfo { hasNextPage endCursor }
+      nodes { id identifier title state { id name type } }
+    }
+    comments(first: 100) {
+      pageInfo { hasNextPage endCursor }
+      nodes { id body createdAt user { id name displayName } }
+    }
+  }
+}`
+
+const getIssueChildrenPageQuery = `
+query GetIssueChildrenPage($id: String!, $after: String!) {
+  issue(id: $id) {
+    children(first: 50, after: $after) {
+      pageInfo { hasNextPage endCursor }
+      nodes { id identifier title state { id name type } }
+    }
+  }
+}`
+
+const getIssueCommentsPageQuery = `
+query GetIssueCommentsPage($id: String!, $after: String!) {
+  issue(id: $id) {
+    comments(first: 100, after: $after) {
+      pageInfo { hasNextPage endCursor }
+      nodes { id body createdAt user { id name displayName } }
+    }
   }
 }`
 
@@ -170,12 +196,23 @@ type gqlIssue struct {
 		ID         string `json:"id"`
 		Identifier string `json:"identifier"`
 	} `json:"parent"`
-	Children struct {
-		Nodes []gqlIssue `json:"nodes"`
-	} `json:"children"`
-	Comments struct {
-		Nodes []Comment `json:"nodes"`
-	} `json:"comments"`
+	Children gqlIssueConnection   `json:"children"`
+	Comments gqlCommentConnection `json:"comments"`
+}
+
+type gqlPageInfo struct {
+	HasNextPage bool   `json:"hasNextPage"`
+	EndCursor   string `json:"endCursor"`
+}
+
+type gqlIssueConnection struct {
+	Nodes    []gqlIssue  `json:"nodes"`
+	PageInfo gqlPageInfo `json:"pageInfo"`
+}
+
+type gqlCommentConnection struct {
+	Nodes    []Comment   `json:"nodes"`
+	PageInfo gqlPageInfo `json:"pageInfo"`
 }
 
 func (g gqlIssue) toIssue() *Issue {
@@ -199,6 +236,60 @@ func (g gqlIssue) toIssue() *Issue {
 	return iss
 }
 
+func (c *Client) paginateChildren(identifier string, issue *gqlIssue) error {
+	for issue.Children.PageInfo.HasNextPage {
+		if issue.Children.PageInfo.EndCursor == "" {
+			return fmt.Errorf("linear: children pagination for issue %q reported hasNextPage without endCursor", identifier)
+		}
+
+		var resp struct {
+			Data struct {
+				Issue struct {
+					Children gqlIssueConnection `json:"children"`
+				} `json:"issue"`
+			} `json:"data"`
+		}
+		if err := c.doGraphQL(getIssueChildrenPageQuery, map[string]interface{}{
+			"id":    identifier,
+			"after": issue.Children.PageInfo.EndCursor,
+		}, &resp); err != nil {
+			return fmt.Errorf("linear: paginate children for issue %q: %w", identifier, err)
+		}
+
+		issue.Children.Nodes = append(issue.Children.Nodes, resp.Data.Issue.Children.Nodes...)
+		issue.Children.PageInfo = resp.Data.Issue.Children.PageInfo
+	}
+
+	return nil
+}
+
+func (c *Client) paginateComments(identifier string, issue *gqlIssue) error {
+	for issue.Comments.PageInfo.HasNextPage {
+		if issue.Comments.PageInfo.EndCursor == "" {
+			return fmt.Errorf("linear: comments pagination for issue %q reported hasNextPage without endCursor", identifier)
+		}
+
+		var resp struct {
+			Data struct {
+				Issue struct {
+					Comments gqlCommentConnection `json:"comments"`
+				} `json:"issue"`
+			} `json:"data"`
+		}
+		if err := c.doGraphQL(getIssueCommentsPageQuery, map[string]interface{}{
+			"id":    identifier,
+			"after": issue.Comments.PageInfo.EndCursor,
+		}, &resp); err != nil {
+			return fmt.Errorf("linear: paginate comments for issue %q: %w", identifier, err)
+		}
+
+		issue.Comments.Nodes = append(issue.Comments.Nodes, resp.Data.Issue.Comments.Nodes...)
+		issue.Comments.PageInfo = resp.Data.Issue.Comments.PageInfo
+	}
+
+	return nil
+}
+
 // GetIssueWithChildren fetches an issue with its children and comments.
 // identifier may be either a Linear UUID or a human identifier like "REL-548".
 func (c *Client) GetIssueWithChildren(identifier string) (*Issue, error) {
@@ -212,6 +303,12 @@ func (c *Client) GetIssueWithChildren(identifier string) (*Issue, error) {
 	}
 	if resp.Data.Issue.ID == "" {
 		return nil, fmt.Errorf("linear: issue %q not found", identifier)
+	}
+	if err := c.paginateChildren(identifier, &resp.Data.Issue); err != nil {
+		return nil, err
+	}
+	if err := c.paginateComments(identifier, &resp.Data.Issue); err != nil {
+		return nil, err
 	}
 	return resp.Data.Issue.toIssue(), nil
 }

--- a/internal/linear/client_test.go
+++ b/internal/linear/client_test.go
@@ -1,0 +1,158 @@
+package linear
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// stubDoer maps request body substrings to canned HTTP responses. First match wins.
+type stubDoer struct {
+	rules    []stubRule
+	Requests [][]byte
+}
+
+type stubRule struct {
+	contains string
+	status   int
+	body     string
+}
+
+func (s *stubDoer) Do(req *http.Request) (*http.Response, error) {
+	b, _ := io.ReadAll(req.Body)
+	s.Requests = append(s.Requests, b)
+	bodyStr := string(b)
+	for _, rule := range s.rules {
+		if strings.Contains(bodyStr, rule.contains) {
+			return &http.Response{
+				StatusCode: rule.status,
+				Body:       io.NopCloser(strings.NewReader(rule.body)),
+				Header:     make(http.Header),
+			}, nil
+		}
+	}
+	return &http.Response{
+		StatusCode: 500,
+		Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"unmatched stub"}]}`)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func fixture(t *testing.T, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("fixture %s: %v", name, err)
+	}
+	return string(data)
+}
+
+func newStubClient(rules []stubRule) (*Client, *stubDoer) {
+	stub := &stubDoer{rules: rules}
+	c := New("test-token")
+	c.HTTP = stub
+	return c, stub
+}
+
+func TestGetIssueWithChildren_PopulatesIssueAndComments(t *testing.T) {
+	c, _ := newStubClient([]stubRule{
+		{contains: "REL-548", status: 200, body: fixture(t, "getIssueWithChildren_REL-548_pre.json")},
+	})
+	iss, err := c.GetIssueWithChildren("REL-548")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if iss.Identifier != "REL-548" {
+		t.Errorf("Identifier = %q, want REL-548", iss.Identifier)
+	}
+	if iss.State.Name != "In Progress" {
+		t.Errorf("State.Name = %q, want In Progress", iss.State.Name)
+	}
+	if len(iss.Comments) != 1 {
+		t.Fatalf("len(Comments) = %d, want 1", len(iss.Comments))
+	}
+	if iss.Comments[0].ID != "556160da" {
+		t.Errorf("Comments[0].ID = %q, want 556160da", iss.Comments[0].ID)
+	}
+	if len(iss.Children) != 0 {
+		t.Errorf("len(Children) = %d, want 0", len(iss.Children))
+	}
+}
+
+func TestGetIssueWithChildren_PopulatesChildren(t *testing.T) {
+	c, _ := newStubClient([]stubRule{
+		{contains: "REL-548", status: 200, body: fixture(t, "getIssueWithChildren_REL-548_post.json")},
+	})
+	iss, err := c.GetIssueWithChildren("REL-548")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(iss.Children) != 2 {
+		t.Fatalf("len(Children) = %d, want 2", len(iss.Children))
+	}
+	if iss.Children[0].Identifier != "REL-558" {
+		t.Errorf("Children[0].Identifier = %q, want REL-558", iss.Children[0].Identifier)
+	}
+	if iss.Children[1].Identifier != "REL-559" {
+		t.Errorf("Children[1].Identifier = %q, want REL-559", iss.Children[1].Identifier)
+	}
+}
+
+func TestGetIssueWithChildren_ErrorsOnHTTPFailure(t *testing.T) {
+	c, _ := newStubClient([]stubRule{
+		{contains: "REL-548", status: 500, body: `internal server error`},
+	})
+	_, err := c.GetIssueWithChildren("REL-548")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "http 500") {
+		t.Errorf("error %q does not mention http 500", err.Error())
+	}
+}
+
+func TestCreateIssue_ReturnsIDAndIdentifier(t *testing.T) {
+	c, _ := newStubClient([]stubRule{
+		{contains: "issueCreate", status: 200, body: fixture(t, "createIssue_success.json")},
+	})
+	iss, err := c.CreateIssue(CreateIssueInput{
+		TeamID:     "team-id",
+		Title:      "QA: Test issue",
+		AssigneeID: "user-id",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if iss.Identifier != "STUB-101" {
+		t.Errorf("Identifier = %q, want STUB-101", iss.Identifier)
+	}
+	if iss.ID == "" {
+		t.Error("ID is empty")
+	}
+}
+
+func TestUpdateIssueState_SuccessReturnsNil(t *testing.T) {
+	c, _ := newStubClient([]stubRule{
+		{contains: "issueUpdate", status: 200, body: fixture(t, "issueUpdate_success.json")},
+	})
+	err := c.UpdateIssueState("issue-uuid", "new-state-id")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateComment_ReturnsCommentID(t *testing.T) {
+	c, _ := newStubClient([]stubRule{
+		{contains: "commentCreate", status: 200, body: fixture(t, "commentCreate_success.json")},
+	})
+	comment, err := c.CreateComment("issue-uuid", "test body")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if comment.ID != "stub-comment-id-0001" {
+		t.Errorf("comment.ID = %q, want stub-comment-id-0001", comment.ID)
+	}
+}

--- a/internal/linear/client_test.go
+++ b/internal/linear/client_test.go
@@ -101,6 +101,139 @@ func TestGetIssueWithChildren_PopulatesChildren(t *testing.T) {
 	}
 }
 
+func TestGetIssueWithChildren_PaginatesChildrenAndComments(t *testing.T) {
+	c, stub := newStubClient([]stubRule{
+		{
+			contains: "GetIssueWithChildren",
+			status:   200,
+			body: `{
+  "data": {
+    "issue": {
+      "id": "aaa00548-0000-0000-0000-000000000000",
+      "identifier": "REL-548",
+      "title": "Add --on-complete hook support for pipeline runs",
+      "url": "https://linear.app/relevant-notion/issue/REL-548/add-on-complete-hook-support",
+      "state": {
+        "id": "state-in-progress-id",
+        "name": "In Progress",
+        "type": "started"
+      },
+      "parent": null,
+      "children": {
+        "pageInfo": {
+          "hasNextPage": true,
+          "endCursor": "child-cursor-1"
+        },
+        "nodes": [
+          {
+            "id": "aaa00558-0000-0000-0000-000000000000",
+            "identifier": "REL-558",
+            "title": "QA: Add --on-complete hook support for pipeline runs",
+            "state": {
+              "id": "state-in-progress-id",
+              "name": "In Progress",
+              "type": "started"
+            }
+          }
+        ]
+      },
+      "comments": {
+        "pageInfo": {
+          "hasNextPage": true,
+          "endCursor": "comment-cursor-1"
+        },
+        "nodes": [
+          {
+            "id": "556160da",
+            "body": "Q HANDOFF / RETEST READY",
+            "createdAt": "2026-04-28T14:00:00.000Z",
+            "user": {
+              "id": "user-q-id",
+              "name": "Q",
+              "displayName": "Q"
+            }
+          }
+        ]
+      }
+    }
+  }
+}`,
+		},
+		{
+			contains: "GetIssueChildrenPage",
+			status:   200,
+			body: `{
+  "data": {
+    "issue": {
+      "children": {
+        "pageInfo": {
+          "hasNextPage": false,
+          "endCursor": ""
+        },
+        "nodes": [
+          {
+            "id": "aaa00559-0000-0000-0000-000000000000",
+            "identifier": "REL-559",
+            "title": "Review: Add --on-complete hook support for pipeline runs",
+            "state": {
+              "id": "state-in-progress-id",
+              "name": "In Progress",
+              "type": "started"
+            }
+          }
+        ]
+      }
+    }
+  }
+}`,
+		},
+		{
+			contains: "GetIssueCommentsPage",
+			status:   200,
+			body: `{
+  "data": {
+    "issue": {
+      "comments": {
+        "pageInfo": {
+          "hasNextPage": false,
+          "endCursor": ""
+        },
+        "nodes": [
+          {
+            "id": "repair-ptr-548",
+            "body": "[fastflow-reconcile] stale-handoff repair applied",
+            "createdAt": "2026-04-29T09:00:00.000Z",
+            "user": null
+          }
+        ]
+      }
+    }
+  }
+}`,
+		},
+	})
+
+	iss, err := c.GetIssueWithChildren("REL-548")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(iss.Children) != 2 {
+		t.Fatalf("len(Children) = %d, want 2", len(iss.Children))
+	}
+	if iss.Children[1].Identifier != "REL-559" {
+		t.Errorf("Children[1].Identifier = %q, want REL-559", iss.Children[1].Identifier)
+	}
+	if len(iss.Comments) != 2 {
+		t.Fatalf("len(Comments) = %d, want 2", len(iss.Comments))
+	}
+	if iss.Comments[1].ID != "repair-ptr-548" {
+		t.Errorf("Comments[1].ID = %q, want repair-ptr-548", iss.Comments[1].ID)
+	}
+	if len(stub.Requests) != 3 {
+		t.Fatalf("len(Requests) = %d, want 3", len(stub.Requests))
+	}
+}
+
 func TestGetIssueWithChildren_ErrorsOnHTTPFailure(t *testing.T) {
 	c, _ := newStubClient([]stubRule{
 		{contains: "REL-548", status: 500, body: `internal server error`},

--- a/internal/linear/testdata/commentCreate_success.json
+++ b/internal/linear/testdata/commentCreate_success.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "commentCreate": {
+      "success": true,
+      "comment": {
+        "id": "stub-comment-id-0001",
+        "body": "stub comment body",
+        "createdAt": "2026-05-01T00:00:00.000Z"
+      }
+    }
+  }
+}

--- a/internal/linear/testdata/createIssue_success.json
+++ b/internal/linear/testdata/createIssue_success.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "issueCreate": {
+      "success": true,
+      "issue": {
+        "id": "stub-qa-uuid-0000-0000-0000-000000000001",
+        "identifier": "STUB-101",
+        "title": "QA: Stub issue title"
+      }
+    }
+  }
+}

--- a/internal/linear/testdata/getIssueWithChildren_REL-548_post.json
+++ b/internal/linear/testdata/getIssueWithChildren_REL-548_post.json
@@ -1,0 +1,66 @@
+{
+  "data": {
+    "issue": {
+      "id": "aaa00548-0000-0000-0000-000000000000",
+      "identifier": "REL-548",
+      "title": "Add --on-complete hook support for pipeline runs",
+      "url": "https://linear.app/relevant-notion/issue/REL-548/add-on-complete-hook-support",
+      "state": {
+        "id": "state-in-review-id",
+        "name": "In Review",
+        "type": "started"
+      },
+      "parent": null,
+      "children": {
+        "nodes": [
+          {
+            "id": "aaa00558-0000-0000-0000-000000000000",
+            "identifier": "REL-558",
+            "title": "QA: Add --on-complete hook support for pipeline runs",
+            "state": {
+              "id": "state-in-progress-id",
+              "name": "In Progress",
+              "type": "started"
+            },
+            "parent": null,
+            "children": { "nodes": [] },
+            "comments": { "nodes": [] }
+          },
+          {
+            "id": "aaa00559-0000-0000-0000-000000000000",
+            "identifier": "REL-559",
+            "title": "Review: Add --on-complete hook support for pipeline runs",
+            "state": {
+              "id": "state-in-progress-id",
+              "name": "In Progress",
+              "type": "started"
+            },
+            "parent": null,
+            "children": { "nodes": [] },
+            "comments": { "nodes": [] }
+          }
+        ]
+      },
+      "comments": {
+        "nodes": [
+          {
+            "id": "556160da",
+            "body": "Q HANDOFF / RETEST READY\n\nBranch: REL-548\nPR: https://github.com/redblacktree/fastflow/pull/36\n\nImplementation complete. --on-complete flag added and tested.",
+            "createdAt": "2026-04-28T14:00:00.000Z",
+            "user": {
+              "id": "user-q-id",
+              "name": "Q",
+              "displayName": "Q"
+            }
+          },
+          {
+            "id": "repair-ptr-548",
+            "body": "[fastflow-reconcile] stale-handoff repair applied\n- QA child: REL-558\n- Review child: REL-559\n- Source comment id: 556160da\n- Tool: fastflow reconcile stale-handoff (REL-546)",
+            "createdAt": "2026-04-29T09:00:00.000Z",
+            "user": null
+          }
+        ]
+      }
+    }
+  }
+}

--- a/internal/linear/testdata/getIssueWithChildren_REL-548_pre.json
+++ b/internal/linear/testdata/getIssueWithChildren_REL-548_pre.json
@@ -1,0 +1,33 @@
+{
+  "data": {
+    "issue": {
+      "id": "aaa00548-0000-0000-0000-000000000000",
+      "identifier": "REL-548",
+      "title": "Add --on-complete hook support for pipeline runs",
+      "url": "https://linear.app/relevant-notion/issue/REL-548/add-on-complete-hook-support",
+      "state": {
+        "id": "state-in-progress-id",
+        "name": "In Progress",
+        "type": "started"
+      },
+      "parent": null,
+      "children": {
+        "nodes": []
+      },
+      "comments": {
+        "nodes": [
+          {
+            "id": "556160da",
+            "body": "Q HANDOFF / RETEST READY\n\nBranch: REL-548\nPR: https://github.com/redblacktree/fastflow/pull/36\n\nImplementation complete. --on-complete flag added and tested.",
+            "createdAt": "2026-04-28T14:00:00.000Z",
+            "user": {
+              "id": "user-q-id",
+              "name": "Q",
+              "displayName": "Q"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/internal/linear/testdata/getIssueWithChildren_REL-549_post.json
+++ b/internal/linear/testdata/getIssueWithChildren_REL-549_post.json
@@ -1,0 +1,66 @@
+{
+  "data": {
+    "issue": {
+      "id": "aaa00549-0000-0000-0000-000000000000",
+      "identifier": "REL-549",
+      "title": "Implement fastflow monitor web dashboard",
+      "url": "https://linear.app/relevant-notion/issue/REL-549/implement-fastflow-monitor-web-dashboard",
+      "state": {
+        "id": "state-in-review-id",
+        "name": "In Review",
+        "type": "started"
+      },
+      "parent": null,
+      "children": {
+        "nodes": [
+          {
+            "id": "aaa00560-0000-0000-0000-000000000000",
+            "identifier": "REL-560",
+            "title": "QA: Implement fastflow monitor web dashboard",
+            "state": {
+              "id": "state-in-progress-id",
+              "name": "In Progress",
+              "type": "started"
+            },
+            "parent": null,
+            "children": { "nodes": [] },
+            "comments": { "nodes": [] }
+          },
+          {
+            "id": "aaa00561-0000-0000-0000-000000000000",
+            "identifier": "REL-561",
+            "title": "Review: Implement fastflow monitor web dashboard",
+            "state": {
+              "id": "state-in-progress-id",
+              "name": "In Progress",
+              "type": "started"
+            },
+            "parent": null,
+            "children": { "nodes": [] },
+            "comments": { "nodes": [] }
+          }
+        ]
+      },
+      "comments": {
+        "nodes": [
+          {
+            "id": "e0a0b191",
+            "body": "Q HANDOFF / RETEST READY\n\nBranch: REL-549\nPR: https://github.com/redblacktree/fastflow/pull/41\n\nMonitor command wired and documented. Dashboard functional.",
+            "createdAt": "2026-04-29T10:00:00.000Z",
+            "user": {
+              "id": "user-q-id",
+              "name": "Q",
+              "displayName": "Q"
+            }
+          },
+          {
+            "id": "repair-ptr-549",
+            "body": "[fastflow-reconcile] stale-handoff repair applied\n- QA child: REL-560\n- Review child: REL-561\n- Source comment id: e0a0b191\n- Tool: fastflow reconcile stale-handoff (REL-546)",
+            "createdAt": "2026-04-30T09:00:00.000Z",
+            "user": null
+          }
+        ]
+      }
+    }
+  }
+}

--- a/internal/linear/testdata/getIssueWithChildren_REL-549_pre.json
+++ b/internal/linear/testdata/getIssueWithChildren_REL-549_pre.json
@@ -1,0 +1,33 @@
+{
+  "data": {
+    "issue": {
+      "id": "aaa00549-0000-0000-0000-000000000000",
+      "identifier": "REL-549",
+      "title": "Implement fastflow monitor web dashboard",
+      "url": "https://linear.app/relevant-notion/issue/REL-549/implement-fastflow-monitor-web-dashboard",
+      "state": {
+        "id": "state-in-progress-id",
+        "name": "In Progress",
+        "type": "started"
+      },
+      "parent": null,
+      "children": {
+        "nodes": []
+      },
+      "comments": {
+        "nodes": [
+          {
+            "id": "e0a0b191",
+            "body": "Q HANDOFF / RETEST READY\n\nBranch: REL-549\nPR: https://github.com/redblacktree/fastflow/pull/41\n\nMonitor command wired and documented. Dashboard functional.",
+            "createdAt": "2026-04-29T10:00:00.000Z",
+            "user": {
+              "id": "user-q-id",
+              "name": "Q",
+              "displayName": "Q"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/internal/linear/testdata/issueUpdate_success.json
+++ b/internal/linear/testdata/issueUpdate_success.json
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "issueUpdate": {
+      "success": true
+    }
+  }
+}

--- a/internal/reconcile/apply.go
+++ b/internal/reconcile/apply.go
@@ -55,13 +55,34 @@ func formatRepairPointer(r *RepairRecord) string {
 	return b.String()
 }
 
+func persistFailure(record *RepairRecord, completedStep string, err error) error {
+	nextStep := record.NextStep
+	if nextStep == "" {
+		nextStep = "inspect-completed-state"
+	}
+	return fmt.Errorf(
+		"apply: persist repair record after %s: %w (next_step=%s; recover by persisting the returned repair record and inspecting completed Linear mutations before any further --apply)",
+		completedStep,
+		err,
+		nextStep,
+	)
+}
+
+func persistRecord(persist func(*RepairRecord) error, record *RepairRecord, completedStep string) error {
+	if err := persist(record); err != nil {
+		return persistFailure(record, completedStep, err)
+	}
+	return nil
+}
+
 // Apply executes the legal repair in the order: re-check idempotence, create QA
 // child, post boundary on QA child, create Review child, move parent to In Review,
 // post repair pointer on parent.
 //
 // After each successful step persist(record) is called so partial failures leave
-// an auditable trail. On failure, the partial record is returned alongside the error.
-// Apply never rolls back completed steps.
+// an auditable trail. Persist failures are fatal and are surfaced explicitly with
+// the completed mutation state and recovery guidance. On failure, the partial
+// record is returned alongside the error. Apply never rolls back completed steps.
 func Apply(
 	m Mutator,
 	parentIdentifier string,
@@ -78,7 +99,9 @@ func Apply(
 	if err != nil {
 		record.LastError = err.Error()
 		record.NextStep = "re-fetch"
-		_ = persist(record)
+		if perr := persistRecord(persist, record, "recording re-fetch failure"); perr != nil {
+			return record, fmt.Errorf("apply: re-fetch %s: %v; additionally %w", parentIdentifier, err, perr)
+		}
 		return record, fmt.Errorf("apply: re-fetch %s: %w", parentIdentifier, err)
 	}
 	facts := Detect(iss)
@@ -99,25 +122,35 @@ func Apply(
 	if err != nil {
 		record.LastError = err.Error()
 		record.NextStep = "create-qa-child"
-		_ = persist(record)
+		if perr := persistRecord(persist, record, "recording create QA child failure"); perr != nil {
+			return record, fmt.Errorf("apply: create QA child: %v; additionally %w", err, perr)
+		}
 		return record, fmt.Errorf("apply: create QA child: %w", err)
 	}
 	record.QAChildID = qaIssue.ID
 	record.QAChildIdentifier = qaIssue.Identifier
 	record.NextStep = "post-qa-boundary"
-	_ = persist(record)
+	record.LastError = ""
+	if err := persistRecord(persist, record, "create QA child"); err != nil {
+		return record, err
+	}
 
 	// Step 3: Post boundary comment on QA child.
 	qaComment, err := m.CreateComment(qaIssue.ID, facts.HandoffCommentBody)
 	if err != nil {
 		record.LastError = err.Error()
 		record.NextStep = "post-qa-boundary"
-		_ = persist(record)
+		if perr := persistRecord(persist, record, "recording post QA boundary failure"); perr != nil {
+			return record, fmt.Errorf("apply: post QA boundary comment: %v; additionally %w", err, perr)
+		}
 		return record, fmt.Errorf("apply: post QA boundary comment: %w", err)
 	}
 	record.QABoundaryCommentID = qaComment.ID
 	record.NextStep = "create-review-child"
-	_ = persist(record)
+	record.LastError = ""
+	if err := persistRecord(persist, record, "post QA boundary comment"); err != nil {
+		return record, err
+	}
 
 	// Step 4: Create Review child.
 	reviewIssue, err := m.CreateIssue(linear.CreateIssueInput{
@@ -129,24 +162,34 @@ func Apply(
 	if err != nil {
 		record.LastError = err.Error()
 		record.NextStep = "create-review-child"
-		_ = persist(record)
+		if perr := persistRecord(persist, record, "recording create Review child failure"); perr != nil {
+			return record, fmt.Errorf("apply: create Review child: %v; additionally %w", err, perr)
+		}
 		return record, fmt.Errorf("apply: create Review child: %w", err)
 	}
 	record.ReviewChildID = reviewIssue.ID
 	record.ReviewChildIdentifier = reviewIssue.Identifier
 	record.NextStep = "move-parent-to-in-review"
-	_ = persist(record)
+	record.LastError = ""
+	if err := persistRecord(persist, record, "create Review child"); err != nil {
+		return record, err
+	}
 
 	// Step 5: Move parent to In Review.
 	if err := m.UpdateIssueState(facts.ParentID, cfg.InReviewStateID); err != nil {
 		record.LastError = err.Error()
 		record.NextStep = "move-parent-to-in-review"
-		_ = persist(record)
+		if perr := persistRecord(persist, record, "recording move parent to In Review failure"); perr != nil {
+			return record, fmt.Errorf("apply: move parent to In Review: %v; additionally %w", err, perr)
+		}
 		return record, fmt.Errorf("apply: move parent to In Review: %w", err)
 	}
 	record.ParentStateChanged = true
 	record.NextStep = "post-repair-pointer"
-	_ = persist(record)
+	record.LastError = ""
+	if err := persistRecord(persist, record, "move parent to In Review"); err != nil {
+		return record, err
+	}
 
 	// Step 6: Post repair pointer on parent.
 	pointerBody := formatRepairPointer(record)
@@ -154,14 +197,18 @@ func Apply(
 	if err != nil {
 		record.LastError = err.Error()
 		record.NextStep = "post-repair-pointer"
-		_ = persist(record)
+		if perr := persistRecord(persist, record, "recording post repair pointer failure"); perr != nil {
+			return record, fmt.Errorf("apply: post repair pointer: %v; additionally %w", err, perr)
+		}
 		return record, fmt.Errorf("apply: post repair pointer: %w", err)
 	}
 	record.RepairPointerID = pointer.ID
 	record.CompletedAt = time.Now().UTC().Format(time.RFC3339)
 	record.NextStep = ""
 	record.LastError = ""
-	_ = persist(record)
+	if err := persistRecord(persist, record, "post repair pointer"); err != nil {
+		return record, err
+	}
 
 	return record, nil
 }

--- a/internal/reconcile/apply.go
+++ b/internal/reconcile/apply.go
@@ -1,0 +1,167 @@
+package reconcile
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/redblacktree/fastflow/internal/linear"
+)
+
+// Mutator is the subset of *linear.Client that Apply needs.
+// Stubbable for tests without touching the network.
+type Mutator interface {
+	GetIssueWithChildren(identifier string) (*linear.Issue, error)
+	CreateIssue(in linear.CreateIssueInput) (*linear.Issue, error)
+	UpdateIssueState(issueID, stateID string) error
+	CreateComment(issueID, body string) (*linear.Comment, error)
+}
+
+// RepairRecord is the audit trail written to disk after Apply (and on failure).
+type RepairRecord struct {
+	ParentIdentifier      string `json:"parent_identifier"`
+	ParentID              string `json:"parent_id"`
+	SourceCommentID       string `json:"source_comment_id"`
+	QAChildID             string `json:"qa_child_id,omitempty"`
+	QAChildIdentifier     string `json:"qa_child_identifier,omitempty"`
+	QABoundaryCommentID   string `json:"qa_boundary_comment_id,omitempty"`
+	ReviewChildID         string `json:"review_child_id,omitempty"`
+	ReviewChildIdentifier string `json:"review_child_identifier,omitempty"`
+	ParentStateChanged    bool   `json:"parent_state_changed"`
+	RepairPointerID       string `json:"repair_pointer_id,omitempty"`
+	StartedAt             string `json:"started_at"`
+	CompletedAt           string `json:"completed_at,omitempty"`
+	LastError             string `json:"last_error,omitempty"`
+	NextStep              string `json:"next_step,omitempty"`
+}
+
+// ErrAlreadyApplied is returned by Apply when the idempotence check blocks.
+// The CLI can distinguish this from a plain network/API failure.
+type ErrAlreadyApplied struct {
+	Reason string
+}
+
+func (e *ErrAlreadyApplied) Error() string { return e.Reason }
+
+// formatRepairPointer produces the canonical repair pointer comment body.
+// The first line is the unique idempotence marker.
+func formatRepairPointer(r *RepairRecord) string {
+	var b strings.Builder
+	b.WriteString(RepairPointerMarker + "\n")
+	b.WriteString("- QA child: " + r.QAChildIdentifier + "\n")
+	b.WriteString("- Review child: " + r.ReviewChildIdentifier + "\n")
+	b.WriteString("- Source comment id: " + r.SourceCommentID + "\n")
+	b.WriteString("- Tool: fastflow reconcile stale-handoff (REL-546)")
+	return b.String()
+}
+
+// Apply executes the legal repair in the order: re-check idempotence, create QA
+// child, post boundary on QA child, create Review child, move parent to In Review,
+// post repair pointer on parent.
+//
+// After each successful step persist(record) is called so partial failures leave
+// an auditable trail. On failure, the partial record is returned alongside the error.
+// Apply never rolls back completed steps.
+func Apply(
+	m Mutator,
+	parentIdentifier string,
+	cfg Config,
+	persist func(*RepairRecord) error,
+) (*RepairRecord, error) {
+	record := &RepairRecord{
+		ParentIdentifier: parentIdentifier,
+		StartedAt:        time.Now().UTC().Format(time.RFC3339),
+	}
+
+	// Step 1: re-fetch and re-run idempotence check.
+	iss, err := m.GetIssueWithChildren(parentIdentifier)
+	if err != nil {
+		record.LastError = err.Error()
+		record.NextStep = "re-fetch"
+		_ = persist(record)
+		return record, fmt.Errorf("apply: re-fetch %s: %w", parentIdentifier, err)
+	}
+	facts := Detect(iss)
+	record.ParentID = facts.ParentID
+	record.SourceCommentID = facts.HandoffCommentID
+
+	if verdict := IdempotenceCheck(facts); verdict.Blocked {
+		return record, &ErrAlreadyApplied{Reason: verdict.Reason}
+	}
+
+	// Step 2: Create QA child.
+	qaIssue, err := m.CreateIssue(linear.CreateIssueInput{
+		TeamID:     cfg.TeamID,
+		Title:      childTitleQAPrefix + facts.ParentTitle,
+		AssigneeID: cfg.QAAssigneeID,
+		ParentID:   facts.ParentID,
+	})
+	if err != nil {
+		record.LastError = err.Error()
+		record.NextStep = "create-qa-child"
+		_ = persist(record)
+		return record, fmt.Errorf("apply: create QA child: %w", err)
+	}
+	record.QAChildID = qaIssue.ID
+	record.QAChildIdentifier = qaIssue.Identifier
+	record.NextStep = "post-qa-boundary"
+	_ = persist(record)
+
+	// Step 3: Post boundary comment on QA child.
+	qaComment, err := m.CreateComment(qaIssue.ID, facts.HandoffCommentBody)
+	if err != nil {
+		record.LastError = err.Error()
+		record.NextStep = "post-qa-boundary"
+		_ = persist(record)
+		return record, fmt.Errorf("apply: post QA boundary comment: %w", err)
+	}
+	record.QABoundaryCommentID = qaComment.ID
+	record.NextStep = "create-review-child"
+	_ = persist(record)
+
+	// Step 4: Create Review child.
+	reviewIssue, err := m.CreateIssue(linear.CreateIssueInput{
+		TeamID:     cfg.TeamID,
+		Title:      childTitleReviewPrefix + facts.ParentTitle,
+		AssigneeID: cfg.ReviewAssigneeID,
+		ParentID:   facts.ParentID,
+	})
+	if err != nil {
+		record.LastError = err.Error()
+		record.NextStep = "create-review-child"
+		_ = persist(record)
+		return record, fmt.Errorf("apply: create Review child: %w", err)
+	}
+	record.ReviewChildID = reviewIssue.ID
+	record.ReviewChildIdentifier = reviewIssue.Identifier
+	record.NextStep = "move-parent-to-in-review"
+	_ = persist(record)
+
+	// Step 5: Move parent to In Review.
+	if err := m.UpdateIssueState(facts.ParentID, cfg.InReviewStateID); err != nil {
+		record.LastError = err.Error()
+		record.NextStep = "move-parent-to-in-review"
+		_ = persist(record)
+		return record, fmt.Errorf("apply: move parent to In Review: %w", err)
+	}
+	record.ParentStateChanged = true
+	record.NextStep = "post-repair-pointer"
+	_ = persist(record)
+
+	// Step 6: Post repair pointer on parent.
+	pointerBody := formatRepairPointer(record)
+	pointer, err := m.CreateComment(facts.ParentID, pointerBody)
+	if err != nil {
+		record.LastError = err.Error()
+		record.NextStep = "post-repair-pointer"
+		_ = persist(record)
+		return record, fmt.Errorf("apply: post repair pointer: %w", err)
+	}
+	record.RepairPointerID = pointer.ID
+	record.CompletedAt = time.Now().UTC().Format(time.RFC3339)
+	record.NextStep = ""
+	record.LastError = ""
+	_ = persist(record)
+
+	return record, nil
+}

--- a/internal/reconcile/apply_test.go
+++ b/internal/reconcile/apply_test.go
@@ -1,0 +1,206 @@
+package reconcile
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/redblacktree/fastflow/internal/linear"
+)
+
+// recordingMutator implements Mutator using fixture issues for reads and
+// records all mutation calls for inspection.
+type recordingMutator struct {
+	issue       *linear.Issue   // returned by GetIssueWithChildren
+	calls       []string        // method names in order
+	createCount int             // tracks CreateIssue invocation count
+	failOn      string          // if set, fail when this method is called (nth-specific: "CreateIssue2")
+	failErr     error
+}
+
+func (m *recordingMutator) GetIssueWithChildren(id string) (*linear.Issue, error) {
+	m.calls = append(m.calls, "GetIssueWithChildren")
+	if m.issue == nil {
+		return nil, errors.New("no fixture issue set")
+	}
+	return m.issue, nil
+}
+
+func (m *recordingMutator) CreateIssue(in linear.CreateIssueInput) (*linear.Issue, error) {
+	m.createCount++
+	callName := "CreateIssue"
+	nthName := "CreateIssue" + string(rune('0'+m.createCount))
+	m.calls = append(m.calls, callName)
+	if m.failOn == callName || m.failOn == nthName {
+		return nil, m.failErr
+	}
+	var id, identifier string
+	if strings.HasPrefix(in.Title, "QA:") {
+		id = "stub-uuid-qa"
+		identifier = "STUB-101"
+	} else {
+		id = "stub-uuid-review"
+		identifier = "STUB-102"
+	}
+	return &linear.Issue{ID: id, Identifier: identifier, Title: in.Title}, nil
+}
+
+func (m *recordingMutator) UpdateIssueState(issueID, stateID string) error {
+	m.calls = append(m.calls, "UpdateIssueState")
+	if m.failOn == "UpdateIssueState" {
+		return m.failErr
+	}
+	return nil
+}
+
+func (m *recordingMutator) CreateComment(issueID, body string) (*linear.Comment, error) {
+	m.calls = append(m.calls, "CreateComment")
+	if m.failOn == "CreateComment" {
+		return nil, m.failErr
+	}
+	id := "stub-comment-" + issueID
+	return &linear.Comment{ID: id, Body: body}, nil
+}
+
+var noPersist = func(_ *RepairRecord) error { return nil }
+
+func applyWithPre548(t *testing.T, mut *recordingMutator) (*RepairRecord, error) {
+	t.Helper()
+	if mut.issue == nil {
+		mut.issue = loadIssueFixture(t, "issue_REL-548_pre.json")
+	}
+	return Apply(mut, "REL-548", testCfg, noPersist)
+}
+
+func TestApply_REL548_pre_executesAllSixSteps_inOrder(t *testing.T) {
+	mut := &recordingMutator{}
+	record, err := applyWithPre548(t, mut)
+	if err != nil {
+		t.Fatalf("Apply error: %v", err)
+	}
+	want := []string{
+		"GetIssueWithChildren",
+		"CreateIssue",    // QA child
+		"CreateComment",  // boundary on QA
+		"CreateIssue",    // Review child
+		"UpdateIssueState",
+		"CreateComment",  // repair pointer on parent
+	}
+	if len(mut.calls) != len(want) {
+		t.Fatalf("calls = %v, want %v", mut.calls, want)
+	}
+	for i, w := range want {
+		if mut.calls[i] != w {
+			t.Errorf("calls[%d] = %q, want %q", i, mut.calls[i], w)
+		}
+	}
+	if record.QAChildIdentifier != "STUB-101" {
+		t.Errorf("QAChildIdentifier = %q", record.QAChildIdentifier)
+	}
+	if record.ReviewChildIdentifier != "STUB-102" {
+		t.Errorf("ReviewChildIdentifier = %q", record.ReviewChildIdentifier)
+	}
+	if !record.ParentStateChanged {
+		t.Error("ParentStateChanged = false")
+	}
+	if record.RepairPointerID == "" {
+		t.Error("RepairPointerID is empty")
+	}
+	if record.CompletedAt == "" {
+		t.Error("CompletedAt is empty")
+	}
+}
+
+func TestApply_REL549_pre_executesAllSixSteps(t *testing.T) {
+	mut := &recordingMutator{issue: loadIssueFixture(t, "issue_REL-549_pre.json")}
+	record, err := Apply(mut, "REL-549", testCfg, noPersist)
+	if err != nil {
+		t.Fatalf("Apply error: %v", err)
+	}
+	if len(mut.calls) != 6 {
+		t.Errorf("len(calls) = %d, want 6: %v", len(mut.calls), mut.calls)
+	}
+	if record.SourceCommentID != "e0a0b191" {
+		t.Errorf("SourceCommentID = %q, want e0a0b191", record.SourceCommentID)
+	}
+}
+
+func TestApply_post_repair_returns_ErrAlreadyApplied_no_writes(t *testing.T) {
+	mut := &recordingMutator{issue: loadIssueFixture(t, "issue_REL-548_post.json")}
+	_, err := Apply(mut, "REL-548", testCfg, noPersist)
+	var alreadyApplied *ErrAlreadyApplied
+	if !errors.As(err, &alreadyApplied) {
+		t.Fatalf("expected ErrAlreadyApplied, got %v", err)
+	}
+	// Only GetIssueWithChildren should have been called — no writes.
+	if len(mut.calls) != 1 || mut.calls[0] != "GetIssueWithChildren" {
+		t.Errorf("unexpected calls: %v", mut.calls)
+	}
+}
+
+func TestApply_failsAtStep4_writesPartialRecord_with_NextStep(t *testing.T) {
+	var persisted []*RepairRecord
+	persist := func(r *RepairRecord) error {
+		cp := *r
+		persisted = append(persisted, &cp)
+		return nil
+	}
+
+	mut := &recordingMutator{
+		issue:   loadIssueFixture(t, "issue_REL-548_pre.json"),
+		failOn:  "CreateIssue2", // fail on second CreateIssue (Review child)
+		failErr: errors.New("linear: create review child failed"),
+	}
+	record, err := Apply(mut, "REL-548", testCfg, persist)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "Review child") {
+		t.Errorf("error %q does not mention Review child", err.Error())
+	}
+	if record.QAChildID == "" {
+		t.Error("QAChildID should be set after step 2 succeeded")
+	}
+	if record.ReviewChildID != "" {
+		t.Error("ReviewChildID should be empty after step 4 failed")
+	}
+	// Check the last persisted record has the NextStep hint.
+	if len(persisted) == 0 {
+		t.Fatal("no persisted records")
+	}
+	last := persisted[len(persisted)-1]
+	if last.NextStep != "create-review-child" {
+		t.Errorf("NextStep = %q, want create-review-child", last.NextStep)
+	}
+}
+
+func TestApply_resumeAfterPartial_isIdempotent(t *testing.T) {
+	// Simulate: QA child exists already (partial apply), Review child does not.
+	// The idempotence check should return ErrAlreadyApplied because only one lane is present.
+	mut := &recordingMutator{issue: loadIssueFixture(t, "issue_only_review_missing.json")}
+	_, err := Apply(mut, "REL-603", testCfg, noPersist)
+	var alreadyApplied *ErrAlreadyApplied
+	if !errors.As(err, &alreadyApplied) {
+		t.Fatalf("expected ErrAlreadyApplied, got %v", err)
+	}
+	if !strings.Contains(alreadyApplied.Reason, "only Review lane missing") {
+		t.Errorf("reason %q does not mention 'only Review lane missing'", alreadyApplied.Reason)
+	}
+}
+
+func TestFormatRepairPointer_pinsCanonicalText(t *testing.T) {
+	r := &RepairRecord{
+		QAChildIdentifier:     "REL-558",
+		ReviewChildIdentifier: "REL-559",
+		SourceCommentID:       "556160da",
+	}
+	got := formatRepairPointer(r)
+	want := "[fastflow-reconcile] stale-handoff repair applied\n" +
+		"- QA child: REL-558\n" +
+		"- Review child: REL-559\n" +
+		"- Source comment id: 556160da\n" +
+		"- Tool: fastflow reconcile stale-handoff (REL-546)"
+	if got != want {
+		t.Errorf("formatRepairPointer mismatch:\ngot:  %q\nwant: %q", got, want)
+	}
+}

--- a/internal/reconcile/apply_test.go
+++ b/internal/reconcile/apply_test.go
@@ -2,6 +2,7 @@ package reconcile
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -171,6 +172,62 @@ func TestApply_failsAtStep4_writesPartialRecord_with_NextStep(t *testing.T) {
 	last := persisted[len(persisted)-1]
 	if last.NextStep != "create-review-child" {
 		t.Errorf("NextStep = %q, want create-review-child", last.NextStep)
+	}
+}
+
+func TestApply_persistFailureAfterCreateQAChild_returnsMutationState(t *testing.T) {
+	persist := func(r *RepairRecord) error {
+		if r.QAChildID != "" {
+			return errors.New("disk full")
+		}
+		return nil
+	}
+
+	mut := &recordingMutator{issue: loadIssueFixture(t, "issue_REL-548_pre.json")}
+	record, err := Apply(mut, "REL-548", testCfg, persist)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "persist repair record after create QA child") {
+		t.Fatalf("error %q does not mention create QA child persist failure", err.Error())
+	}
+	if !strings.Contains(err.Error(), "next_step=post-qa-boundary") {
+		t.Fatalf("error %q does not mention next_step=post-qa-boundary", err.Error())
+	}
+	if record.QAChildID == "" {
+		t.Fatal("QAChildID should be set after successful QA creation")
+	}
+	if len(mut.calls) != 2 {
+		t.Fatalf("calls = %v, want [GetIssueWithChildren CreateIssue]", mut.calls)
+	}
+}
+
+func TestApply_persistFailureAfterPostRepairPointer_returnsErrorNotSuccess(t *testing.T) {
+	persistCalls := 0
+	persist := func(_ *RepairRecord) error {
+		persistCalls++
+		if persistCalls == 5 {
+			return fmt.Errorf("write audit record")
+		}
+		return nil
+	}
+
+	mut := &recordingMutator{issue: loadIssueFixture(t, "issue_REL-548_pre.json")}
+	record, err := Apply(mut, "REL-548", testCfg, persist)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "persist repair record after post repair pointer") {
+		t.Fatalf("error %q does not mention post repair pointer persist failure", err.Error())
+	}
+	if record.RepairPointerID == "" {
+		t.Fatal("RepairPointerID should be set after successful pointer creation")
+	}
+	if record.CompletedAt == "" {
+		t.Fatal("CompletedAt should be set before final persist")
+	}
+	if len(mut.calls) != 6 {
+		t.Fatalf("calls = %v, want 6 operations through final mutation", mut.calls)
 	}
 }
 

--- a/internal/reconcile/apply_test.go
+++ b/internal/reconcile/apply_test.go
@@ -11,10 +11,10 @@ import (
 // recordingMutator implements Mutator using fixture issues for reads and
 // records all mutation calls for inspection.
 type recordingMutator struct {
-	issue       *linear.Issue   // returned by GetIssueWithChildren
-	calls       []string        // method names in order
-	createCount int             // tracks CreateIssue invocation count
-	failOn      string          // if set, fail when this method is called (nth-specific: "CreateIssue2")
+	issue       *linear.Issue // returned by GetIssueWithChildren
+	calls       []string      // method names in order
+	createCount int           // tracks CreateIssue invocation count
+	failOn      string        // if set, fail when this method is called (nth-specific: "CreateIssue2")
 	failErr     error
 }
 
@@ -80,11 +80,11 @@ func TestApply_REL548_pre_executesAllSixSteps_inOrder(t *testing.T) {
 	}
 	want := []string{
 		"GetIssueWithChildren",
-		"CreateIssue",    // QA child
-		"CreateComment",  // boundary on QA
-		"CreateIssue",    // Review child
+		"CreateIssue",   // QA child
+		"CreateComment", // boundary on QA
+		"CreateIssue",   // Review child
 		"UpdateIssueState",
-		"CreateComment",  // repair pointer on parent
+		"CreateComment", // repair pointer on parent
 	}
 	if len(mut.calls) != len(want) {
 		t.Fatalf("calls = %v, want %v", mut.calls, want)

--- a/internal/reconcile/e2e_test.go
+++ b/internal/reconcile/e2e_test.go
@@ -1,0 +1,144 @@
+package reconcile
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/redblacktree/fastflow/internal/linear"
+)
+
+// e2eStubDoer wires a *linear.Client to fixture files for end-to-end testing.
+// It maps request body substrings to canned fixture responses (first match wins).
+type e2eStubDoer struct {
+	rules    []e2eRule
+	Requests [][]byte
+}
+
+type e2eRule struct {
+	contains string
+	fixFile  string // if set, load from linear testdata; body overrides if non-empty
+	body     string
+	status   int
+}
+
+func (s *e2eStubDoer) Do(req *http.Request) (*http.Response, error) {
+	b, _ := io.ReadAll(req.Body)
+	s.Requests = append(s.Requests, b)
+	bodyStr := string(b)
+	for _, rule := range s.rules {
+		if strings.Contains(bodyStr, rule.contains) {
+			body := rule.body
+			if body == "" && rule.fixFile != "" {
+				data, err := os.ReadFile(filepath.Join("..", "linear", "testdata", rule.fixFile))
+				if err != nil {
+					return nil, err
+				}
+				body = string(data)
+			}
+			status := rule.status
+			if status == 0 {
+				status = 200
+			}
+			return &http.Response{
+				StatusCode: status,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     make(http.Header),
+			}, nil
+		}
+	}
+	return &http.Response{
+		StatusCode: 500,
+		Body:       io.NopCloser(strings.NewReader(`{"errors":[{"message":"e2e: unmatched stub"}]}`)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+// preRules returns e2e stub rules for the pre-repair scenario.
+// Using operation names as matchers avoids false matches when the
+// comment body contains the issue identifier (e.g. "Branch: REL-548").
+func preRules548() []e2eRule {
+	return []e2eRule{
+		// GET — operation name is unique; won't collide with mutations
+		{contains: "GetIssueWithChildren", fixFile: "getIssueWithChildren_REL-548_pre.json"},
+		{contains: "issueCreate", fixFile: "createIssue_success.json"},
+		{contains: "issueUpdate", fixFile: "issueUpdate_success.json"},
+		{contains: "commentCreate", fixFile: "commentCreate_success.json"},
+	}
+}
+
+func TestE2E_ProposalAndApply(t *testing.T) {
+	stub := &e2eStubDoer{rules: preRules548()}
+	client := linear.New("test-token")
+	client.HTTP = stub
+
+	// 1. Fetch and detect.
+	iss, err := client.GetIssueWithChildren("REL-548")
+	if err != nil {
+		t.Fatalf("GetIssueWithChildren: %v", err)
+	}
+	facts := Detect(iss)
+	if facts.HandoffCommentID != "556160da" {
+		t.Errorf("HandoffCommentID = %q, want 556160da", facts.HandoffCommentID)
+	}
+
+	// 2. Propose.
+	proposal, verdict := Propose(facts, testCfg)
+	if verdict.Blocked {
+		t.Fatalf("propose blocked: %s", verdict.Reason)
+	}
+	if !strings.HasPrefix(proposal.IntendedQATitle, "QA:") {
+		t.Errorf("IntendedQATitle = %q", proposal.IntendedQATitle)
+	}
+
+	// 3. Apply — re-wire stub for the six-call sequence.
+	stub.rules = preRules548()
+	stub.Requests = nil // reset request log
+
+	record, err := Apply(client, "REL-548", testCfg, func(_ *RepairRecord) error { return nil })
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	// Verify six HTTP calls were made in canonical order:
+	// GET, POST(issueCreate/QA), POST(commentCreate/boundary),
+	// POST(issueCreate/Review), POST(issueUpdate), POST(commentCreate/pointer)
+	if len(stub.Requests) != 6 {
+		t.Errorf("expected 6 HTTP requests, got %d", len(stub.Requests))
+	}
+
+	// Spot-check the first call has the identifier.
+	if !strings.Contains(string(stub.Requests[0]), "REL-548") {
+		t.Error("first request should contain REL-548")
+	}
+
+	if record.CompletedAt == "" {
+		t.Error("CompletedAt is empty after successful apply")
+	}
+	if record.RepairPointerID == "" {
+		t.Error("RepairPointerID is empty after successful apply")
+	}
+}
+
+func TestE2E_PostRepair_ProposesNoDuplicate(t *testing.T) {
+	stub := &e2eStubDoer{
+		rules: []e2eRule{
+			{contains: "GetIssueWithChildren", fixFile: "getIssueWithChildren_REL-548_post.json"},
+		},
+	}
+	client := linear.New("test-token")
+	client.HTTP = stub
+
+	iss, err := client.GetIssueWithChildren("REL-548")
+	if err != nil {
+		t.Fatalf("GetIssueWithChildren: %v", err)
+	}
+	facts := Detect(iss)
+	_, verdict := Propose(facts, testCfg)
+	if !verdict.Blocked {
+		t.Error("post-repair issue should produce a blocked verdict (no duplicate)")
+	}
+}

--- a/internal/reconcile/stale_handoff.go
+++ b/internal/reconcile/stale_handoff.go
@@ -23,39 +23,39 @@ var (
 		"Duplicate": true,
 	}
 
-	prURLRegex   = regexp.MustCompile(`https?://(?:www\.)?github\.com/[^\s)]+/pull/\d+`)
-	branchRegex  = regexp.MustCompile(`(?mi)^\s*(?:[-*•]\s*)?branch\s*[:=]\s*(\S+)`)
+	prURLRegex  = regexp.MustCompile(`https?://(?:www\.)?github\.com/[^\s)]+/pull/\d+`)
+	branchRegex = regexp.MustCompile(`(?mi)^\s*(?:[-*•]\s*)?branch\s*[:=]\s*(\S+)`)
 )
 
 // StaleHandoffFacts is what Detect produces — all evidence used by Propose,
 // IdempotenceCheck, and Apply. Fully serializable for audit.
 type StaleHandoffFacts struct {
-	ParentID                string `json:"parent_id"`
-	ParentIdentifier        string `json:"parent_identifier"`
-	ParentTitle             string `json:"parent_title"`
-	ParentStateName         string `json:"parent_state_name"`
-	ParentStateID           string `json:"parent_state_id"`
-	HandoffCommentID        string `json:"handoff_comment_id"`
-	HandoffCommentBody      string `json:"handoff_comment_body"`
-	HasQAChild              bool   `json:"has_qa_child"`
-	HasReviewChild          bool   `json:"has_review_child"`
-	QAChildIdentifier       string `json:"qa_child_identifier,omitempty"`
-	ReviewChildIdentifier   string `json:"review_child_identifier,omitempty"`
-	HasRepairPointer        bool   `json:"has_repair_pointer"`
-	RepairPointerCommentID  string `json:"repair_pointer_comment_id,omitempty"`
-	DerivedPRURL            string `json:"derived_pr_url,omitempty"`
-	DerivedBranch           string `json:"derived_branch,omitempty"`
+	ParentID               string `json:"parent_id"`
+	ParentIdentifier       string `json:"parent_identifier"`
+	ParentTitle            string `json:"parent_title"`
+	ParentStateName        string `json:"parent_state_name"`
+	ParentStateID          string `json:"parent_state_id"`
+	HandoffCommentID       string `json:"handoff_comment_id"`
+	HandoffCommentBody     string `json:"handoff_comment_body"`
+	HasQAChild             bool   `json:"has_qa_child"`
+	HasReviewChild         bool   `json:"has_review_child"`
+	QAChildIdentifier      string `json:"qa_child_identifier,omitempty"`
+	ReviewChildIdentifier  string `json:"review_child_identifier,omitempty"`
+	HasRepairPointer       bool   `json:"has_repair_pointer"`
+	RepairPointerCommentID string `json:"repair_pointer_comment_id,omitempty"`
+	DerivedPRURL           string `json:"derived_pr_url,omitempty"`
+	DerivedBranch          string `json:"derived_branch,omitempty"`
 }
 
 // Detect inspects an already-fetched issue and returns the facts needed by
 // proposal/idempotence/apply. Pure function, no I/O.
 func Detect(issue *linear.Issue) *StaleHandoffFacts {
 	facts := &StaleHandoffFacts{
-		ParentID:        issue.ID,
+		ParentID:         issue.ID,
 		ParentIdentifier: issue.Identifier,
-		ParentTitle:     issue.Title,
-		ParentStateName: issue.State.Name,
-		ParentStateID:   issue.State.ID,
+		ParentTitle:      issue.Title,
+		ParentStateName:  issue.State.Name,
+		ParentStateID:    issue.State.ID,
 	}
 
 	// Scan comments: find the first handoff comment and any repair pointer.

--- a/internal/reconcile/stale_handoff.go
+++ b/internal/reconcile/stale_handoff.go
@@ -1,0 +1,219 @@
+package reconcile
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/redblacktree/fastflow/internal/linear"
+)
+
+// RepairPointerMarker is the first line of the repair pointer comment and the
+// unique idempotence marker.
+const RepairPointerMarker = "[fastflow-reconcile] stale-handoff repair applied"
+
+var (
+	qHandoffMarkerHandoff  = "Q HANDOFF"
+	qHandoffMarkerRetest   = "RETEST READY"
+	childTitleQAPrefix     = "QA: "
+	childTitleReviewPrefix = "Review: "
+
+	parentTerminalStateNames = map[string]bool{
+		"Done":      true,
+		"Canceled":  true,
+		"Duplicate": true,
+	}
+
+	prURLRegex   = regexp.MustCompile(`https?://(?:www\.)?github\.com/[^\s)]+/pull/\d+`)
+	branchRegex  = regexp.MustCompile(`(?mi)^\s*(?:[-*•]\s*)?branch\s*[:=]\s*(\S+)`)
+)
+
+// StaleHandoffFacts is what Detect produces — all evidence used by Propose,
+// IdempotenceCheck, and Apply. Fully serializable for audit.
+type StaleHandoffFacts struct {
+	ParentID                string `json:"parent_id"`
+	ParentIdentifier        string `json:"parent_identifier"`
+	ParentTitle             string `json:"parent_title"`
+	ParentStateName         string `json:"parent_state_name"`
+	ParentStateID           string `json:"parent_state_id"`
+	HandoffCommentID        string `json:"handoff_comment_id"`
+	HandoffCommentBody      string `json:"handoff_comment_body"`
+	HasQAChild              bool   `json:"has_qa_child"`
+	HasReviewChild          bool   `json:"has_review_child"`
+	QAChildIdentifier       string `json:"qa_child_identifier,omitempty"`
+	ReviewChildIdentifier   string `json:"review_child_identifier,omitempty"`
+	HasRepairPointer        bool   `json:"has_repair_pointer"`
+	RepairPointerCommentID  string `json:"repair_pointer_comment_id,omitempty"`
+	DerivedPRURL            string `json:"derived_pr_url,omitempty"`
+	DerivedBranch           string `json:"derived_branch,omitempty"`
+}
+
+// Detect inspects an already-fetched issue and returns the facts needed by
+// proposal/idempotence/apply. Pure function, no I/O.
+func Detect(issue *linear.Issue) *StaleHandoffFacts {
+	facts := &StaleHandoffFacts{
+		ParentID:        issue.ID,
+		ParentIdentifier: issue.Identifier,
+		ParentTitle:     issue.Title,
+		ParentStateName: issue.State.Name,
+		ParentStateID:   issue.State.ID,
+	}
+
+	// Scan comments: find the first handoff comment and any repair pointer.
+	for _, c := range issue.Comments {
+		trimmed := strings.TrimSpace(c.Body)
+
+		if facts.HandoffCommentID == "" {
+			if strings.Contains(trimmed, qHandoffMarkerHandoff) ||
+				strings.Contains(trimmed, qHandoffMarkerRetest) {
+				facts.HandoffCommentID = c.ID
+				facts.HandoffCommentBody = trimmed
+			}
+		}
+
+		// The first line of the repair pointer is the unique marker.
+		firstLine := trimmed
+		if idx := strings.Index(trimmed, "\n"); idx >= 0 {
+			firstLine = trimmed[:idx]
+		}
+		if firstLine == RepairPointerMarker && !facts.HasRepairPointer {
+			facts.HasRepairPointer = true
+			facts.RepairPointerCommentID = c.ID
+		}
+	}
+
+	// Scan children for QA / Review lanes.
+	for _, child := range issue.Children {
+		if strings.HasPrefix(child.Title, childTitleQAPrefix) && !facts.HasQAChild {
+			facts.HasQAChild = true
+			facts.QAChildIdentifier = child.Identifier
+		}
+		if strings.HasPrefix(child.Title, childTitleReviewPrefix) && !facts.HasReviewChild {
+			facts.HasReviewChild = true
+			facts.ReviewChildIdentifier = child.Identifier
+		}
+	}
+
+	// Optional enrichment from the handoff comment body.
+	if facts.HandoffCommentBody != "" {
+		if m := prURLRegex.FindString(facts.HandoffCommentBody); m != "" {
+			facts.DerivedPRURL = m
+		}
+		if m := branchRegex.FindStringSubmatch(facts.HandoffCommentBody); len(m) > 1 {
+			facts.DerivedBranch = m[1]
+		}
+	}
+
+	return facts
+}
+
+// IdempotenceVerdict expresses whether a repair would be a no-op and why.
+type IdempotenceVerdict struct {
+	Blocked bool
+	// Reason is human-readable and stable enough to assert on in tests.
+	Reason string
+}
+
+// IdempotenceCheck returns Blocked=true with a fact-grounded reason whenever
+// the repair cannot or should not be applied. Conditions evaluated in order:
+//  1. No Q HANDOFF comment found
+//  2. Parent in terminal state
+//  3. Repair pointer already present
+//  4. Both QA and Review children already exist
+//  5. Only QA lane missing (Review exists but QA doesn't)
+//  6. Only Review lane missing (QA exists but Review doesn't)
+//  7. Handoff comment body is empty after trim
+func IdempotenceCheck(facts *StaleHandoffFacts) IdempotenceVerdict {
+	if facts.HandoffCommentID == "" {
+		return IdempotenceVerdict{Blocked: true,
+			Reason: "no Q HANDOFF / RETEST READY comment found on parent"}
+	}
+	if parentTerminalStateNames[facts.ParentStateName] {
+		return IdempotenceVerdict{Blocked: true,
+			Reason: "parent is in terminal state " + facts.ParentStateName + "; will not propose repair"}
+	}
+	if facts.HasRepairPointer {
+		return IdempotenceVerdict{Blocked: true,
+			Reason: "parent already has repair pointer comment " + facts.RepairPointerCommentID}
+	}
+	if facts.HasQAChild && facts.HasReviewChild {
+		return IdempotenceVerdict{Blocked: true,
+			Reason: "parent already has QA child " + facts.QAChildIdentifier +
+				" and Review child " + facts.ReviewChildIdentifier}
+	}
+	if facts.HasQAChild {
+		return IdempotenceVerdict{Blocked: true,
+			Reason: "parent already has QA child " + facts.QAChildIdentifier +
+				"; only Review lane missing — out of scope for this slice"}
+	}
+	if facts.HasReviewChild {
+		return IdempotenceVerdict{Blocked: true,
+			Reason: "parent already has Review child " + facts.ReviewChildIdentifier +
+				"; only QA lane missing — out of scope for this slice"}
+	}
+	if strings.TrimSpace(facts.HandoffCommentBody) == "" {
+		return IdempotenceVerdict{Blocked: true,
+			Reason: "Q HANDOFF comment is empty after trim; cannot derive boundary"}
+	}
+	return IdempotenceVerdict{Blocked: false}
+}
+
+// Config is the operator-supplied identity bundle.
+type Config struct {
+	TeamID            string
+	InReviewStateID   string
+	InReviewStateName string // for display; defaults to "In Review"
+	QAAssigneeID      string
+	ReviewAssigneeID  string
+}
+
+// Proposal is the operator-readable repair plan.
+type Proposal struct {
+	ParentIdentifier         string   `json:"parent_identifier"`
+	ParentID                 string   `json:"parent_id"`
+	ParentTitle              string   `json:"parent_title"`
+	ParentStateName          string   `json:"parent_state_name"`
+	SourceCommentID          string   `json:"source_comment_id"`
+	MissingLanes             []string `json:"missing_lanes"`
+	IntendedQATitle          string   `json:"intended_qa_title"`
+	IntendedQAAssigneeID     string   `json:"intended_qa_assignee_id"`
+	IntendedReviewTitle      string   `json:"intended_review_title"`
+	IntendedReviewAssigneeID string   `json:"intended_review_assignee_id"`
+	IntendedParentStateID    string   `json:"intended_parent_state_id"`
+	IntendedParentStateName  string   `json:"intended_parent_state_name"`
+	Boundary                 string   `json:"boundary"`
+	DerivedPRURL             string   `json:"derived_pr_url,omitempty"`
+	DerivedBranch            string   `json:"derived_branch,omitempty"`
+}
+
+// Propose returns a Proposal iff IdempotenceCheck says not blocked.
+// If blocked, returns (nil, verdict).
+func Propose(facts *StaleHandoffFacts, cfg Config) (*Proposal, IdempotenceVerdict) {
+	verdict := IdempotenceCheck(facts)
+	if verdict.Blocked {
+		return nil, verdict
+	}
+
+	stateName := cfg.InReviewStateName
+	if stateName == "" {
+		stateName = "In Review"
+	}
+
+	p := &Proposal{
+		ParentIdentifier:         facts.ParentIdentifier,
+		ParentID:                 facts.ParentID,
+		ParentTitle:              facts.ParentTitle,
+		ParentStateName:          facts.ParentStateName,
+		SourceCommentID:          facts.HandoffCommentID,
+		MissingLanes:             []string{"QA", "Review"},
+		IntendedQATitle:          childTitleQAPrefix + facts.ParentTitle,
+		IntendedQAAssigneeID:     cfg.QAAssigneeID,
+		IntendedReviewTitle:      childTitleReviewPrefix + facts.ParentTitle,
+		IntendedReviewAssigneeID: cfg.ReviewAssigneeID,
+		IntendedParentStateID:    cfg.InReviewStateID,
+		IntendedParentStateName:  stateName,
+		Boundary:                 facts.HandoffCommentBody,
+		DerivedPRURL:             facts.DerivedPRURL,
+		DerivedBranch:            facts.DerivedBranch,
+	}
+	return p, IdempotenceVerdict{Blocked: false}
+}

--- a/internal/reconcile/stale_handoff_test.go
+++ b/internal/reconcile/stale_handoff_test.go
@@ -1,0 +1,262 @@
+package reconcile
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/redblacktree/fastflow/internal/linear"
+)
+
+// issueFixture mirrors the flat fixture format stored in testdata/.
+type issueFixture struct {
+	ID         string               `json:"id"`
+	Identifier string               `json:"identifier"`
+	Title      string               `json:"title"`
+	URL        string               `json:"url"`
+	State      linear.WorkflowState `json:"state"`
+	Children   []issueFixture       `json:"children"`
+	Comments   []linear.Comment     `json:"comments"`
+}
+
+func fixtureToIssue(f issueFixture) linear.Issue {
+	iss := linear.Issue{
+		ID:         f.ID,
+		Identifier: f.Identifier,
+		Title:      f.Title,
+		URL:        f.URL,
+		State:      f.State,
+		Comments:   f.Comments,
+	}
+	for _, child := range f.Children {
+		c := fixtureToIssue(child)
+		iss.Children = append(iss.Children, c)
+	}
+	return iss
+}
+
+func loadIssueFixture(t *testing.T, name string) *linear.Issue {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("loadIssueFixture %s: %v", name, err)
+	}
+	var f issueFixture
+	if err := json.Unmarshal(data, &f); err != nil {
+		t.Fatalf("loadIssueFixture %s: unmarshal: %v", name, err)
+	}
+	iss := fixtureToIssue(f)
+	return &iss
+}
+
+var testCfg = Config{
+	TeamID:            "test-team-id",
+	InReviewStateID:   "state-in-review-id",
+	InReviewStateName: "In Review",
+	QAAssigneeID:      "test-qa-assignee-id",
+	ReviewAssigneeID:  "test-review-assignee-id",
+}
+
+func TestDetect_REL548_pre_capturesHandoffCommentID(t *testing.T) {
+	iss := loadIssueFixture(t, "issue_REL-548_pre.json")
+	facts := Detect(iss)
+	if facts.HandoffCommentID != "556160da" {
+		t.Errorf("HandoffCommentID = %q, want 556160da", facts.HandoffCommentID)
+	}
+	if facts.HasQAChild {
+		t.Error("HasQAChild = true, want false")
+	}
+	if facts.HasReviewChild {
+		t.Error("HasReviewChild = true, want false")
+	}
+	if facts.DerivedPRURL != "https://github.com/redblacktree/fastflow/pull/36" {
+		t.Errorf("DerivedPRURL = %q", facts.DerivedPRURL)
+	}
+	if facts.DerivedBranch != "REL-548" {
+		t.Errorf("DerivedBranch = %q, want REL-548", facts.DerivedBranch)
+	}
+}
+
+func TestDetect_REL549_pre_capturesHandoffCommentID(t *testing.T) {
+	iss := loadIssueFixture(t, "issue_REL-549_pre.json")
+	facts := Detect(iss)
+	if facts.HandoffCommentID != "e0a0b191" {
+		t.Errorf("HandoffCommentID = %q, want e0a0b191", facts.HandoffCommentID)
+	}
+	if facts.HasQAChild || facts.HasReviewChild {
+		t.Error("pre-repair fixture should have no QA/Review children")
+	}
+}
+
+func TestDetect_post_repair_setsHasQAandReview(t *testing.T) {
+	iss := loadIssueFixture(t, "issue_REL-548_post.json")
+	facts := Detect(iss)
+	if !facts.HasQAChild {
+		t.Error("HasQAChild = false, want true")
+	}
+	if !facts.HasReviewChild {
+		t.Error("HasReviewChild = false, want true")
+	}
+	if facts.QAChildIdentifier != "REL-558" {
+		t.Errorf("QAChildIdentifier = %q, want REL-558", facts.QAChildIdentifier)
+	}
+	if facts.ReviewChildIdentifier != "REL-559" {
+		t.Errorf("ReviewChildIdentifier = %q, want REL-559", facts.ReviewChildIdentifier)
+	}
+	if !facts.HasRepairPointer {
+		t.Error("HasRepairPointer = false, want true")
+	}
+}
+
+func TestIdempotenceCheck_pre_repair_unblocked(t *testing.T) {
+	for _, name := range []string{"issue_REL-548_pre.json", "issue_REL-549_pre.json"} {
+		t.Run(name, func(t *testing.T) {
+			iss := loadIssueFixture(t, name)
+			facts := Detect(iss)
+			verdict := IdempotenceCheck(facts)
+			if verdict.Blocked {
+				t.Errorf("Blocked = true, want false; reason: %s", verdict.Reason)
+			}
+		})
+	}
+}
+
+func TestIdempotenceCheck_post_repair_blocked_with_specific_reason(t *testing.T) {
+	iss := loadIssueFixture(t, "issue_REL-548_post.json")
+	facts := Detect(iss)
+	verdict := IdempotenceCheck(facts)
+	if !verdict.Blocked {
+		t.Fatal("Blocked = false, want true")
+	}
+	// Repair pointer is found first in precedence order.
+	if !strings.Contains(verdict.Reason, "repair-ptr-548") {
+		t.Errorf("Reason %q does not mention repair-ptr-548", verdict.Reason)
+	}
+}
+
+func TestIdempotenceCheck_no_handoff_blocked(t *testing.T) {
+	iss := loadIssueFixture(t, "issue_no_handoff.json")
+	facts := Detect(iss)
+	verdict := IdempotenceCheck(facts)
+	if !verdict.Blocked {
+		t.Fatal("Blocked = false, want true")
+	}
+	if !strings.HasPrefix(verdict.Reason, "no Q HANDOFF") {
+		t.Errorf("Reason %q does not start with 'no Q HANDOFF'", verdict.Reason)
+	}
+}
+
+func TestIdempotenceCheck_done_parent_blocked(t *testing.T) {
+	iss := loadIssueFixture(t, "issue_done_parent.json")
+	facts := Detect(iss)
+	verdict := IdempotenceCheck(facts)
+	if !verdict.Blocked {
+		t.Fatal("Blocked = false, want true")
+	}
+	if !strings.Contains(verdict.Reason, "Done") {
+		t.Errorf("Reason %q does not mention Done", verdict.Reason)
+	}
+}
+
+func TestIdempotenceCheck_only_qa_missing_blocked(t *testing.T) {
+	// Review child present, QA missing → HasReviewChild=true → "only QA lane missing"
+	iss := loadIssueFixture(t, "issue_only_qa_missing.json")
+	facts := Detect(iss)
+	verdict := IdempotenceCheck(facts)
+	if !verdict.Blocked {
+		t.Fatal("Blocked = false, want true")
+	}
+	if !strings.Contains(verdict.Reason, "only QA lane missing") {
+		t.Errorf("Reason %q does not mention 'only QA lane missing'", verdict.Reason)
+	}
+}
+
+func TestIdempotenceCheck_only_review_missing_blocked(t *testing.T) {
+	// QA child present, Review missing → HasQAChild=true → "only Review lane missing"
+	iss := loadIssueFixture(t, "issue_only_review_missing.json")
+	facts := Detect(iss)
+	verdict := IdempotenceCheck(facts)
+	if !verdict.Blocked {
+		t.Fatal("Blocked = false, want true")
+	}
+	if !strings.Contains(verdict.Reason, "only Review lane missing") {
+		t.Errorf("Reason %q does not mention 'only Review lane missing'", verdict.Reason)
+	}
+}
+
+func TestIdempotenceCheck_already_repaired_with_pointer_blocked(t *testing.T) {
+	iss := loadIssueFixture(t, "issue_already_repaired_with_pointer.json")
+	facts := Detect(iss)
+	verdict := IdempotenceCheck(facts)
+	if !verdict.Blocked {
+		t.Fatal("Blocked = false, want true")
+	}
+	if !strings.Contains(verdict.Reason, "repair-ptr-605") {
+		t.Errorf("Reason %q does not mention repair pointer comment id", verdict.Reason)
+	}
+}
+
+func TestPropose_pre_repair_REL548_emits_QA_style_intent(t *testing.T) {
+	iss := loadIssueFixture(t, "issue_REL-548_pre.json")
+	facts := Detect(iss)
+	proposal, verdict := Propose(facts, testCfg)
+	if verdict.Blocked {
+		t.Fatalf("Propose returned blocked: %s", verdict.Reason)
+	}
+	if proposal == nil {
+		t.Fatal("proposal is nil")
+	}
+	wantQATitle := "QA: Add --on-complete hook support for pipeline runs"
+	if proposal.IntendedQATitle != wantQATitle {
+		t.Errorf("IntendedQATitle = %q, want %q", proposal.IntendedQATitle, wantQATitle)
+	}
+	if proposal.IntendedQAAssigneeID != testCfg.QAAssigneeID {
+		t.Errorf("IntendedQAAssigneeID = %q", proposal.IntendedQAAssigneeID)
+	}
+	if proposal.IntendedReviewAssigneeID != testCfg.ReviewAssigneeID {
+		t.Errorf("IntendedReviewAssigneeID = %q", proposal.IntendedReviewAssigneeID)
+	}
+	if len(proposal.MissingLanes) != 2 {
+		t.Errorf("MissingLanes = %v, want [QA Review]", proposal.MissingLanes)
+	}
+	if !strings.Contains(proposal.Boundary, "Q HANDOFF") {
+		t.Errorf("Boundary %q missing Q HANDOFF", proposal.Boundary)
+	}
+	if proposal.SourceCommentID != "556160da" {
+		t.Errorf("SourceCommentID = %q, want 556160da", proposal.SourceCommentID)
+	}
+}
+
+func TestPropose_pre_repair_REL549_emits_REL560_style_intent(t *testing.T) {
+	iss := loadIssueFixture(t, "issue_REL-549_pre.json")
+	facts := Detect(iss)
+	proposal, verdict := Propose(facts, testCfg)
+	if verdict.Blocked {
+		t.Fatalf("Propose returned blocked: %s", verdict.Reason)
+	}
+	if proposal.SourceCommentID != "e0a0b191" {
+		t.Errorf("SourceCommentID = %q, want e0a0b191", proposal.SourceCommentID)
+	}
+	wantQATitle := "QA: Implement fastflow monitor web dashboard"
+	if proposal.IntendedQATitle != wantQATitle {
+		t.Errorf("IntendedQATitle = %q, want %q", proposal.IntendedQATitle, wantQATitle)
+	}
+}
+
+func TestPropose_post_repair_returns_nil_proposal_with_blocked_verdict(t *testing.T) {
+	for _, name := range []string{"issue_REL-548_post.json", "issue_REL-549_post.json"} {
+		t.Run(name, func(t *testing.T) {
+			iss := loadIssueFixture(t, name)
+			facts := Detect(iss)
+			proposal, verdict := Propose(facts, testCfg)
+			if !verdict.Blocked {
+				t.Error("verdict not blocked for post-repair fixture")
+			}
+			if proposal != nil {
+				t.Error("proposal is non-nil for post-repair fixture")
+			}
+		})
+	}
+}

--- a/internal/reconcile/testdata/issue_REL-548_post.json
+++ b/internal/reconcile/testdata/issue_REL-548_post.json
@@ -1,0 +1,37 @@
+{
+  "id": "aaa00548-0000-0000-0000-000000000000",
+  "identifier": "REL-548",
+  "title": "Add --on-complete hook support for pipeline runs",
+  "url": "https://linear.app/relevant-notion/issue/REL-548/add-on-complete-hook-support",
+  "state": { "id": "state-in-review-id", "name": "In Review", "type": "started" },
+  "children": [
+    {
+      "id": "aaa00558-0000-0000-0000-000000000000",
+      "identifier": "REL-558",
+      "title": "QA: Add --on-complete hook support for pipeline runs",
+      "state": { "id": "state-in-progress-id", "name": "In Progress", "type": "started" },
+      "children": [],
+      "comments": []
+    },
+    {
+      "id": "aaa00559-0000-0000-0000-000000000000",
+      "identifier": "REL-559",
+      "title": "Review: Add --on-complete hook support for pipeline runs",
+      "state": { "id": "state-in-progress-id", "name": "In Progress", "type": "started" },
+      "children": [],
+      "comments": []
+    }
+  ],
+  "comments": [
+    {
+      "id": "556160da",
+      "body": "Q HANDOFF / RETEST READY\n\nBranch: REL-548\nPR: https://github.com/redblacktree/fastflow/pull/36\n\nImplementation complete. --on-complete flag added and tested.",
+      "createdAt": "2026-04-28T14:00:00.000Z"
+    },
+    {
+      "id": "repair-ptr-548",
+      "body": "[fastflow-reconcile] stale-handoff repair applied\n- QA child: REL-558\n- Review child: REL-559\n- Source comment id: 556160da\n- Tool: fastflow reconcile stale-handoff (REL-546)",
+      "createdAt": "2026-04-29T09:00:00.000Z"
+    }
+  ]
+}

--- a/internal/reconcile/testdata/issue_REL-548_pre.json
+++ b/internal/reconcile/testdata/issue_REL-548_pre.json
@@ -1,0 +1,15 @@
+{
+  "id": "aaa00548-0000-0000-0000-000000000000",
+  "identifier": "REL-548",
+  "title": "Add --on-complete hook support for pipeline runs",
+  "url": "https://linear.app/relevant-notion/issue/REL-548/add-on-complete-hook-support",
+  "state": { "id": "state-in-progress-id", "name": "In Progress", "type": "started" },
+  "children": [],
+  "comments": [
+    {
+      "id": "556160da",
+      "body": "Q HANDOFF / RETEST READY\n\nBranch: REL-548\nPR: https://github.com/redblacktree/fastflow/pull/36\n\nImplementation complete. --on-complete flag added and tested.",
+      "createdAt": "2026-04-28T14:00:00.000Z"
+    }
+  ]
+}

--- a/internal/reconcile/testdata/issue_REL-549_post.json
+++ b/internal/reconcile/testdata/issue_REL-549_post.json
@@ -1,0 +1,37 @@
+{
+  "id": "aaa00549-0000-0000-0000-000000000000",
+  "identifier": "REL-549",
+  "title": "Implement fastflow monitor web dashboard",
+  "url": "https://linear.app/relevant-notion/issue/REL-549/implement-fastflow-monitor-web-dashboard",
+  "state": { "id": "state-in-review-id", "name": "In Review", "type": "started" },
+  "children": [
+    {
+      "id": "aaa00560-0000-0000-0000-000000000000",
+      "identifier": "REL-560",
+      "title": "QA: Implement fastflow monitor web dashboard",
+      "state": { "id": "state-in-progress-id", "name": "In Progress", "type": "started" },
+      "children": [],
+      "comments": []
+    },
+    {
+      "id": "aaa00561-0000-0000-0000-000000000000",
+      "identifier": "REL-561",
+      "title": "Review: Implement fastflow monitor web dashboard",
+      "state": { "id": "state-in-progress-id", "name": "In Progress", "type": "started" },
+      "children": [],
+      "comments": []
+    }
+  ],
+  "comments": [
+    {
+      "id": "e0a0b191",
+      "body": "Q HANDOFF / RETEST READY\n\nBranch: REL-549\nPR: https://github.com/redblacktree/fastflow/pull/41\n\nMonitor command wired and documented. Dashboard functional.",
+      "createdAt": "2026-04-29T10:00:00.000Z"
+    },
+    {
+      "id": "repair-ptr-549",
+      "body": "[fastflow-reconcile] stale-handoff repair applied\n- QA child: REL-560\n- Review child: REL-561\n- Source comment id: e0a0b191\n- Tool: fastflow reconcile stale-handoff (REL-546)",
+      "createdAt": "2026-04-30T09:00:00.000Z"
+    }
+  ]
+}

--- a/internal/reconcile/testdata/issue_REL-549_pre.json
+++ b/internal/reconcile/testdata/issue_REL-549_pre.json
@@ -1,0 +1,15 @@
+{
+  "id": "aaa00549-0000-0000-0000-000000000000",
+  "identifier": "REL-549",
+  "title": "Implement fastflow monitor web dashboard",
+  "url": "https://linear.app/relevant-notion/issue/REL-549/implement-fastflow-monitor-web-dashboard",
+  "state": { "id": "state-in-progress-id", "name": "In Progress", "type": "started" },
+  "children": [],
+  "comments": [
+    {
+      "id": "e0a0b191",
+      "body": "Q HANDOFF / RETEST READY\n\nBranch: REL-549\nPR: https://github.com/redblacktree/fastflow/pull/41\n\nMonitor command wired and documented. Dashboard functional.",
+      "createdAt": "2026-04-29T10:00:00.000Z"
+    }
+  ]
+}

--- a/internal/reconcile/testdata/issue_already_repaired_with_pointer.json
+++ b/internal/reconcile/testdata/issue_already_repaired_with_pointer.json
@@ -1,0 +1,37 @@
+{
+  "id": "aaa00bbb-0000-0000-0000-000000000000",
+  "identifier": "REL-605",
+  "title": "Issue already repaired",
+  "url": "https://linear.app/relevant-notion/issue/REL-605/already-repaired",
+  "state": { "id": "state-in-review-id", "name": "In Review", "type": "started" },
+  "children": [
+    {
+      "id": "aaa00qa5-0000-0000-0000-000000000000",
+      "identifier": "REL-606",
+      "title": "QA: Issue already repaired",
+      "state": { "id": "state-in-progress-id", "name": "In Progress", "type": "started" },
+      "children": [],
+      "comments": []
+    },
+    {
+      "id": "aaa00rv5-0000-0000-0000-000000000000",
+      "identifier": "REL-607",
+      "title": "Review: Issue already repaired",
+      "state": { "id": "state-in-progress-id", "name": "In Progress", "type": "started" },
+      "children": [],
+      "comments": []
+    }
+  ],
+  "comments": [
+    {
+      "id": "cmt-handoff-605",
+      "body": "Q HANDOFF / RETEST READY\n\nBranch: REL-605\nReady.",
+      "createdAt": "2026-04-20T10:00:00.000Z"
+    },
+    {
+      "id": "repair-ptr-605",
+      "body": "[fastflow-reconcile] stale-handoff repair applied\n- QA child: REL-606\n- Review child: REL-607\n- Source comment id: cmt-handoff-605\n- Tool: fastflow reconcile stale-handoff (REL-546)",
+      "createdAt": "2026-04-21T09:00:00.000Z"
+    }
+  ]
+}

--- a/internal/reconcile/testdata/issue_done_parent.json
+++ b/internal/reconcile/testdata/issue_done_parent.json
@@ -1,0 +1,15 @@
+{
+  "id": "aaa00yyy-0000-0000-0000-000000000000",
+  "identifier": "REL-600",
+  "title": "A completed issue with a handoff comment",
+  "url": "https://linear.app/relevant-notion/issue/REL-600/completed-issue",
+  "state": { "id": "state-done-id", "name": "Done", "type": "completed" },
+  "children": [],
+  "comments": [
+    {
+      "id": "cmt-handoff-done",
+      "body": "Q HANDOFF / RETEST READY\n\nBranch: REL-600\nAll done.",
+      "createdAt": "2026-04-10T10:00:00.000Z"
+    }
+  ]
+}

--- a/internal/reconcile/testdata/issue_no_handoff.json
+++ b/internal/reconcile/testdata/issue_no_handoff.json
@@ -1,0 +1,15 @@
+{
+  "id": "aaa00xxx-0000-0000-0000-000000000000",
+  "identifier": "REL-599",
+  "title": "Some issue with no handoff comment",
+  "url": "https://linear.app/relevant-notion/issue/REL-599/some-issue",
+  "state": { "id": "state-in-progress-id", "name": "In Progress", "type": "started" },
+  "children": [],
+  "comments": [
+    {
+      "id": "cmt-ordinary-1",
+      "body": "Working on this ticket now.",
+      "createdAt": "2026-04-01T10:00:00.000Z"
+    }
+  ]
+}

--- a/internal/reconcile/testdata/issue_only_qa_missing.json
+++ b/internal/reconcile/testdata/issue_only_qa_missing.json
@@ -1,0 +1,24 @@
+{
+  "id": "aaa00zzz-0000-0000-0000-000000000000",
+  "identifier": "REL-601",
+  "title": "Issue with only QA child missing",
+  "url": "https://linear.app/relevant-notion/issue/REL-601/only-qa-missing",
+  "state": { "id": "state-in-progress-id", "name": "In Progress", "type": "started" },
+  "children": [
+    {
+      "id": "aaa00rev-0000-0000-0000-000000000000",
+      "identifier": "REL-602",
+      "title": "Review: Issue with only QA child missing",
+      "state": { "id": "state-in-progress-id", "name": "In Progress", "type": "started" },
+      "children": [],
+      "comments": []
+    }
+  ],
+  "comments": [
+    {
+      "id": "cmt-handoff-601",
+      "body": "Q HANDOFF / RETEST READY\n\nBranch: REL-601\nReady for review.",
+      "createdAt": "2026-04-15T10:00:00.000Z"
+    }
+  ]
+}

--- a/internal/reconcile/testdata/issue_only_review_missing.json
+++ b/internal/reconcile/testdata/issue_only_review_missing.json
@@ -1,0 +1,24 @@
+{
+  "id": "aaa00aaa-0000-0000-0000-000000000000",
+  "identifier": "REL-603",
+  "title": "Issue with only Review child missing",
+  "url": "https://linear.app/relevant-notion/issue/REL-603/only-review-missing",
+  "state": { "id": "state-in-progress-id", "name": "In Progress", "type": "started" },
+  "children": [
+    {
+      "id": "aaa00qa3-0000-0000-0000-000000000000",
+      "identifier": "REL-604",
+      "title": "QA: Issue with only Review child missing",
+      "state": { "id": "state-in-progress-id", "name": "In Progress", "type": "started" },
+      "children": [],
+      "comments": []
+    }
+  ],
+  "comments": [
+    {
+      "id": "cmt-handoff-603",
+      "body": "Q HANDOFF / RETEST READY\n\nBranch: REL-603\nReady for QA.",
+      "createdAt": "2026-04-16T10:00:00.000Z"
+    }
+  ]
+}


### PR DESCRIPTION
## What problem does this solve?

When a parent Linear issue receives a `Q HANDOFF / RETEST READY` comment but no QA or Review child lanes were ever created, the ticket stalls invisibly — no assignee gets work, no state changes, and the issue stays blocked. The only fix has been manual: create two child issues, move the parent state, and backfill the handoff boundary. This PR automates that detection and repair.

## What changed?

### `internal/linear` — new Linear GraphQL client
A minimal, stubbable client that wraps the Linear GraphQL API:
- `GetIssueWithChildren` — fetches an issue with up to 50 children and 100 comments
- `CreateIssue` — creates a new child issue with optional assignee, parent, and description
- `UpdateIssueState` — moves an issue to a target workflow state
- `CreateComment` — posts a comment on an issue

The `httpDoer` interface makes the client fully testable without network calls.

### `internal/reconcile` — detection, proposal, and apply logic

**`stale_handoff.go`** (pure, no I/O):
- `Detect(issue)` — inspects a fetched issue and returns `StaleHandoffFacts`: handoff comment, children scan, repair pointer presence, derived PR URL / branch
- `IdempotenceCheck(facts)` — returns a `Blocked` verdict with a fact-grounded reason for each no-op case: no handoff comment, terminal parent state, existing repair pointer, both lanes already present, only one lane missing
- `Propose(facts, cfg)` — wraps detect + idempotence into a human-readable `Proposal` struct

**`apply.go`** — stepwise, auditable apply:
1. Re-fetches the issue and re-runs idempotence (race-safe)
2. Creates `QA: <parent title>` child assigned to the QA owner
3. Posts the canonical handoff boundary as a comment on the QA child
4. Creates `Review: <parent title>` child assigned to the reviewer
5. Moves parent to `In Review`
6. Posts a repair pointer comment on the parent (`[fastflow-reconcile] stale-handoff repair applied`)

Each step persists a `RepairRecord` JSON to disk before proceeding, so a partial failure leaves an auditable trail. `ErrAlreadyApplied` lets the CLI distinguish a no-op from a real error.

### `cmd/fastflow/reconcile.go` — CLI command
`fastflow reconcile stale-handoff --issue REL-548 [--apply]`

Dry-run (default) fetches the issue, runs detect+propose, and prints a fact-backed proposal. `--apply` executes the repair and writes the audit record to `<runDir>/reconcile-<issue>.json`. All five config values accept environment variables with flag overrides.

### `README.md` — operator documentation
Documents the command, required environment variables, and usage examples.

## Tests

| Package | Coverage |
|---|---|
| `internal/linear` | HTTP mock round-trips for all four operations |
| `internal/reconcile` | Unit tests against 9 fixtures (REL-548 pre/post, REL-549 pre/post, no-handoff, done-parent, already-repaired, only-QA-missing, only-Review-missing); stepwise apply tests with stub Mutator; e2e flow tests |
| `cmd/fastflow` | CLI integration tests with golden proposal output for REL-548 and REL-549 pre-repair fixtures |

**All tests pass:**
```
ok  github.com/redblacktree/fastflow/internal/linear
ok  github.com/redblacktree/fastflow/internal/reconcile
ok  github.com/redblacktree/fastflow/cmd/fastflow
```

## Acceptance scenarios

| Scenario | Status |
|---|---|
| REL-548 pre-repair facts → proposes REL-558/REL-559-style repair | Covered by golden test `proposal_REL-548_pre.txt` |
| REL-549 pre-repair facts → proposes REL-560/REL-561-style repair | Covered by golden test `proposal_REL-549_pre.txt` |
| Post-repair REL-548/REL-549 → no-op (repair pointer present) | Covered by `issue_already_repaired_with_pointer.json` fixture |
| Done/Canceled/Duplicate parent → explicit no-op | Covered by `issue_done_parent.json` fixture |
| No Q HANDOFF comment → explicit no-op | Covered by `issue_no_handoff.json` fixture |
| Only one lane missing → explicit no-op (out of scope for this slice) | Covered by `issue_only_qa_missing.json` and `issue_only_review_missing.json` fixtures |

## How to verify

- [x] `go test ./internal/linear/... ./internal/reconcile/... ./cmd/fastflow/...` — all pass
- [ ] Dry-run against live REL-548 (post-repair): `LINEAR_API_KEY=... fastflow reconcile stale-handoff --issue REL-548` → should print `No-op: parent already has repair pointer comment …`
- [ ] Dry-run against live REL-549 (post-repair): `LINEAR_API_KEY=... fastflow reconcile stale-handoff --issue REL-549` → same no-op

## Changelog

`fastflow reconcile stale-handoff` — new command that detects parent Linear issues with a `Q HANDOFF / RETEST READY` comment but missing QA and Review child lanes, then prints a fact-backed proposal or executes a safe, idempotent repair with `--apply`.

Closes REL-546