### PR TITLE
[codex] Pass workdir to judge backend

### DIFF
--- a/internal/judge/judge.go
+++ b/internal/judge/judge.go
@@ -44,6 +44,7 @@ func (j *Judge) Evaluate(ctx *EvaluationContext) (*Result, error) {
 	res, err := j.Backend.Invoke(backend.InvokeOptions{
 		Prompt:   prompt,
 		Model:    j.Model,
+		WorkDir:  ctx.WorkDir,
 		MaxTurns: j.MaxTurns,
 		Debug:    j.Debug,
 	})
@@ -62,6 +63,7 @@ type EvaluationContext struct {
 	JudgePrompt    string
 	CLIOutput      string
 	OutputFilePath string
+	WorkDir        string
 }
 
 // buildPrompt constructs the evaluation prompt for the judge.

--- a/internal/judge/judge_test.go
+++ b/internal/judge/judge_test.go
@@ -8,14 +8,16 @@ import (
 
 // fakeBackend is a minimal backend.Backend for testing the judge.
 type fakeBackend struct {
-	output string
-	err    error
+	output      string
+	err         error
+	lastOptions backend.InvokeOptions
 }
 
-func (f *fakeBackend) Name() string                                         { return "fake" }
-func (f *fakeBackend) DefaultModel() string                                 { return "fake-model" }
-func (f *fakeBackend) Capabilities() backend.Capabilities                  { return backend.Capabilities{} }
-func (f *fakeBackend) Invoke(_ backend.InvokeOptions) (*backend.InvokeResult, error) {
+func (f *fakeBackend) Name() string                       { return "fake" }
+func (f *fakeBackend) DefaultModel() string               { return "fake-model" }
+func (f *fakeBackend) Capabilities() backend.Capabilities { return backend.Capabilities{} }
+func (f *fakeBackend) Invoke(opts backend.InvokeOptions) (*backend.InvokeResult, error) {
+	f.lastOptions = opts
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -92,5 +94,20 @@ func TestParseResponse_Unparseable(t *testing.T) {
 	}
 	if res.Success {
 		t.Error("expected Success=false for unparseable response")
+	}
+}
+
+func TestEvaluatePassesWorkDirToBackend(t *testing.T) {
+	fb := &fakeBackend{output: "YES: ok"}
+	j := NewJudge(fb, "m")
+	_, err := j.Evaluate(&EvaluationContext{
+		JudgePrompt: "did it work?",
+		WorkDir:     "/tmp/work",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fb.lastOptions.WorkDir != "/tmp/work" {
+		t.Errorf("WorkDir = %q, want /tmp/work", fb.lastOptions.WorkDir)
 	}
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -848,6 +848,7 @@ func (r *Runner) evaluateStage(ctx *RunContext, stageName string, stage *config.
 		JudgePrompt:    judgePrompt,
 		CLIOutput:      result.Output,
 		OutputFilePath: filepath.Join(ctx.RunDir, stageName+".md"),
+		WorkDir:        ctx.WorkDir,
 	}
 
 	return j.Evaluate(evalCtx)


### PR DESCRIPTION
## Summary

Fixes Codex judge execution by passing the pipeline working directory through the judge evaluation context into backend invocation.

## Root Cause

PR #38 made judge evaluation backend-agnostic, but judge.Evaluate invoked the backend without WorkDir. The Codex backend always emits codex exec ... --cd <workdir>, so a Codex judge received an empty --cd value and failed during e2e validation.

## Changes

- Add WorkDir to judge.EvaluationContext.
- Pass ctx.WorkDir from runner stage evaluation into the judge context.
- Include WorkDir in backend.InvokeOptions for judge backend calls.
- Add a unit test that verifies judge evaluation forwards the workdir to the backend.

## Verification

- go test ./...
- git diff --check
- Codex e2e in a disposable repo using codex-quick with judge_backend: codex; the workflow completed, created commit 174bf81 Update Codex e2e marker, and changed only TODO.md.