### PR TITLE
Add Codex context handoff and stage-specific model defaults

### DIFF
--- a/.agents/skills/source-command-commit/SKILL.md
+++ b/.agents/skills/source-command-commit/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: "source-command-commit"
+description: "Create git commits with user approval and no Codex attribution"
+---
+
+# source-command-commit
+
+Use this skill when the user asks to run the migrated source command `commit`.
+
+## Command Template
+
+# Commit Changes
+
+You are tasked with creating git commits for the changes made during this session.
+
+## Process:
+
+1. **Think about what changed:**
+   - Review the conversation history and understand what was accomplished
+   - Run `git status` to see current changes
+   - Run `git diff` to understand the modifications
+   - Consider whether changes should be one commit or multiple logical commits
+
+2. **Plan your commit(s):**
+   - Identify which files belong together
+   - Draft clear, descriptive commit messages
+   - Use imperative mood in commit messages
+   - Focus on why the changes were made, not just what
+
+3. **Present your plan to the user:**
+   - List the files you plan to add for each commit
+   - Show the commit message(s) you'll use
+   - Ask: "I plan to create [N] commit(s) with these changes. Shall I proceed?"
+
+4. **Execute upon confirmation:**
+   - Use `git add` with specific files (never use `-A` or `.`)
+   - Create commits with your planned messages
+   - Show the result with `git log --oneline -n [number]`
+
+## Important:
+- **NEVER add co-author information or Codex attribution**
+- Commits should be authored solely by the user
+- Do not include any "Generated with Codex" messages
+- Do not add "Co-Authored-By" lines
+- Write commit messages as if the user wrote them
+
+## Remember:
+- You have the full context of what was done in this session
+- Group related changes together
+- Keep commits focused and atomic when possible
+- The user trusts your judgment - they asked you to commit

--- a/.agents/skills/source-command-create-handoff/SKILL.md
+++ b/.agents/skills/source-command-create-handoff/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: "source-command-create-handoff"
+description: "Create handoff document for transferring work to another session"
+---
+
+# source-command-create-handoff
+
+Use this skill when the user asks to run the migrated source command `create_handoff`.
+
+## Command Template
+
+# Create Handoff
+
+You are tasked with writing a handoff document to hand off your work to another agent in a new session. You will create a handoff document that is thorough, but also **concise**. The goal is to compact and summarize your context without losing any of the key details of what you're working on.
+
+
+## Process
+### 1. Filepath & Metadata
+Use the following information to understand how to create your document:
+    - create your file under `thoughts/shared/handoffs/ENG-XXXX/YYYY-MM-DD_HH-MM-SS_ENG-ZZZZ_description.md`, where:
+        - YYYY-MM-DD is today's date
+        - HH-MM-SS is the hours, minutes and seconds based on the current time, in 24-hour format (i.e. use `13:00` for `1:00 pm`)
+        - ENG-XXXX is the ticket number (replace with `general` if no ticket)
+        - ENG-ZZZZ is the ticket number (omit if no ticket)
+        - description is a brief kebab-case description
+    - Run the `scripts/spec_metadata.sh` script to generate all relevant metadata
+    - Examples:
+        - With ticket: `2025-01-08_13-55-22_ENG-2166_create-context-compaction.md`
+        - Without ticket: `2025-01-08_13-55-22_create-context-compaction.md`
+
+### 2. Handoff writing.
+using the above conventions, write your document. use the defined filepath, and the following YAML frontmatter pattern. Use the metadata gathered in step 1, Structure the document with YAML frontmatter followed by content:
+
+Use the following template structure:
+```markdown
+---
+date: [Current date and time with timezone in ISO format]
+researcher: [Researcher name from thoughts status]
+git_commit: [Current commit hash]
+branch: [Current branch name]
+repository: [Repository name]
+topic: "[Feature/Task Name] Implementation Strategy"
+tags: [implementation, strategy, relevant-component-names]
+status: complete
+last_updated: [Current date in YYYY-MM-DD format]
+last_updated_by: [Researcher name]
+type: implementation_strategy
+---
+
+# Handoff: ENG-XXXX {very concise description}
+
+## Task(s)
+{description of the task(s) that you were working on, along with the status of each (completed, work in progress, planned/discussed). If you are working on an implementation plan, make sure to call out which phase you are on. Make sure to reference the plan document and/or research document(s) you are working from that were provided to you at the beginning of the session, if applicable.}
+
+## Critical References
+{List any critical specification documents, architectural decisions, or design docs that must be followed. Include only 2-3 most important file paths. Leave blank if none.}
+
+## Recent changes
+{describe recent changes made to the codebase that you made in line:file syntax}
+
+## Learnings
+{describe important things that you learned - e.g. patterns, root causes of bugs, or other important pieces of information someone that is picking up your work after you should know. consider listing explicit file paths.}
+
+## Artifacts
+{ an exhaustive list of artifacts you produced or updated as filepaths and/or file:line references - e.g. paths to feature documents, implementation plans, etc that should be read in order to resume your work.}
+
+## Action Items & Next Steps
+{ a list of action items and next steps for the next agent to accomplish based on your tasks and their statuses}
+
+## Other Notes
+{ other notes, references, or useful information - e.g. where relevant sections of the codebase are, where relevant documents are, or other important things you leanrned that you want to pass on but that don't fall into the above categories}
+```
+---
+
+### 3. Approve and Sync
+Run `humanlayer thoughts sync` to save the document.
+
+Once this is completed, you should respond to the user with the template between <template_response></template_response> XML tags. do NOT include the tags in your response.
+
+<template_response>
+Handoff created and synced! You can resume from this handoff in a new session with the following command:
+
+```bash
+/resume_handoff path/to/handoff.md
+```
+</template_response>
+
+for example (between <example_response></example_response> XML tags - do NOT include these tags in your actual response to the user)
+
+<example_response>
+Handoff created and synced! You can resume from this handoff in a new session with the following command:
+
+```bash
+/resume_handoff thoughts/shared/handoffs/ENG-2166/2025-01-08_13-44-55_ENG-2166_create-context-compaction.md
+```
+</example_response>
+
+---
+##.  Additional Notes & Instructions
+- **more information, not less**. This is a guideline that defines the minimum of what a handoff should be. Always feel free to include more information if necessary.
+- **be thorough and precise**. include both top-level objectives, and lower-level details as necessary.
+- **avoid excessive code snippets**. While a brief snippet to describe some key change is important, avoid large code blocks or diffs; do not include one unless it's necessary (e.g. pertains to an error you're debugging). Prefer using `/path/to/file.ext:line` references that an agent can follow later when it's ready, e.g. `packages/dashboard/src/app/dashboard/page.tsx:12-24`

--- a/.agents/skills/source-command-create-plan/SKILL.md
+++ b/.agents/skills/source-command-create-plan/SKILL.md
@@ -1,0 +1,455 @@
+---
+name: "source-command-create-plan"
+description: "Create detailed implementation plans through interactive research and iteration"
+---
+
+# source-command-create-plan
+
+Use this skill when the user asks to run the migrated source command `create_plan`.
+
+## Command Template
+
+# Implementation Plan
+
+You are tasked with creating detailed implementation plans through an interactive, iterative process. You should be skeptical, thorough, and work collaboratively with the user to produce high-quality technical specifications.
+
+## Initial Response
+
+When this command is invoked:
+
+1. **Check if parameters were provided**:
+   - If a file path or ticket reference was provided as a parameter, skip the default message
+   - Immediately read any provided files FULLY
+   - Begin the research process
+
+2. **If no parameters provided**, respond with:
+```
+I'll help you create a detailed implementation plan. Let me start by understanding what we're building.
+
+Please provide:
+1. The task/ticket description (or reference to a ticket file)
+2. Any relevant context, constraints, or specific requirements
+3. Links to related research or previous implementations
+
+I'll analyze this information and work with you to create a comprehensive plan.
+
+Tip: You can also invoke this command with a ticket file directly: `/create_plan thoughts/allison/tickets/eng_1234.md`
+For deeper analysis, try: `/create_plan think deeply about thoughts/allison/tickets/eng_1234.md`
+```
+
+Then wait for the user's input.
+
+## Process Steps
+
+### Step 1: Context Gathering & Initial Analysis
+
+1. **Read all mentioned files immediately and FULLY**:
+   - Ticket files (e.g., `thoughts/allison/tickets/eng_1234.md`)
+   - Research documents
+   - Related implementation plans
+   - Any JSON/data files mentioned
+   - **IMPORTANT**: Use the Read tool WITHOUT limit/offset parameters to read entire files
+   - **CRITICAL**: DO NOT spawn sub-tasks before reading these files yourself in the main context
+   - **NEVER** read files partially - if a file is mentioned, read it completely
+
+2. **Spawn initial research tasks to gather context**:
+   Before asking the user any questions, use specialized agents to research in parallel:
+
+   - Use the **codebase-locator** agent to find all files related to the ticket/task
+   - Use the **codebase-analyzer** agent to understand how the current implementation works
+   - If relevant, use the **thoughts-locator** agent to find any existing thoughts documents about this feature
+   - If a Linear ticket is mentioned, use the **linear-ticket-reader** agent to get full details
+
+   These agents will:
+   - Find relevant source files, configs, and tests
+   - Identify the specific directories to focus on (e.g., if WUI is mentioned, they'll focus on humanlayer-wui/)
+   - Trace data flow and key functions
+   - Return detailed explanations with file:line references
+
+3. **Read all files identified by research tasks**:
+   - After research tasks complete, read ALL files they identified as relevant
+   - Read them FULLY into the main context
+   - This ensures you have complete understanding before proceeding
+
+4. **Analyze and verify understanding**:
+   - Cross-reference the ticket requirements with actual code
+   - Identify any discrepancies or misunderstandings
+   - Note assumptions that need verification
+   - Determine true scope based on codebase reality
+
+5. **Present informed understanding and focused questions**:
+   ```
+   Based on the ticket and my research of the codebase, I understand we need to [accurate summary].
+
+   I've found that:
+   - [Current implementation detail with file:line reference]
+   - [Relevant pattern or constraint discovered]
+   - [Potential complexity or edge case identified]
+
+   Questions that my research couldn't answer:
+   - [Specific technical question that requires human judgment]
+   - [Business logic clarification]
+   - [Design preference that affects implementation]
+   ```
+
+   Only ask questions that you genuinely cannot answer through code investigation.
+
+### Step 2: Research & Discovery
+
+After getting initial clarifications:
+
+1. **If the user corrects any misunderstanding**:
+   - DO NOT just accept the correction
+   - Spawn new research tasks to verify the correct information
+   - Read the specific files/directories they mention
+   - Only proceed once you've verified the facts yourself
+
+2. **Create a research todo list** using TodoWrite to track exploration tasks
+
+3. **Spawn parallel sub-tasks for comprehensive research**:
+   - Create multiple Task agents to research different aspects concurrently
+   - Use the right agent for each type of research:
+
+   **For deeper investigation:**
+   - **codebase-locator** - To find more specific files (e.g., "find all files that handle [specific component]")
+   - **codebase-analyzer** - To understand implementation details (e.g., "analyze how [system] works")
+   - **codebase-pattern-finder** - To find similar features we can model after
+
+   **For historical context:**
+   - **thoughts-locator** - To find any research, plans, or decisions about this area
+   - **thoughts-analyzer** - To extract key insights from the most relevant documents
+
+   **For related tickets:**
+   - **linear-searcher** - To find similar issues or past implementations
+
+   Each agent knows how to:
+   - Find the right files and code patterns
+   - Identify conventions and patterns to follow
+   - Look for integration points and dependencies
+   - Return specific file:line references
+   - Find tests and examples
+
+3. **Wait for ALL sub-tasks to complete** before proceeding
+
+4. **Present findings and design options**:
+   ```
+   Based on my research, here's what I found:
+
+   **Current State:**
+   - [Key discovery about existing code]
+   - [Pattern or convention to follow]
+
+   **Design Options:**
+   1. [Option A] - [pros/cons]
+   2. [Option B] - [pros/cons]
+
+   **Open Questions:**
+   - [Technical uncertainty]
+   - [Design decision needed]
+
+   Which approach aligns best with your vision?
+   ```
+
+### Step 3: Plan Structure Development
+
+Once aligned on approach:
+
+1. **Create initial plan outline**:
+   ```
+   Here's my proposed plan structure:
+
+   ## Overview
+   [1-2 sentence summary]
+
+   ## Implementation Phases:
+   1. [Phase name] - [what it accomplishes]
+   2. [Phase name] - [what it accomplishes]
+   3. [Phase name] - [what it accomplishes]
+
+   Does this phasing make sense? Should I adjust the order or granularity?
+   ```
+
+2. **Get feedback on structure** before writing details
+
+### Step 4: Detailed Plan Writing
+
+After structure approval:
+
+1. **Write the plan** to `thoughts/shared/plans/YYYY-MM-DD-ENG-XXXX-description.md`
+   - Format: `YYYY-MM-DD-ENG-XXXX-description.md` where:
+     - YYYY-MM-DD is today's date
+     - ENG-XXXX is the ticket number (omit if no ticket)
+     - description is a brief kebab-case description
+   - Examples:
+     - With ticket: `2025-01-08-ENG-1478-parent-child-tracking.md`
+     - Without ticket: `2025-01-08-improve-error-handling.md`
+2. **Use this template structure**:
+
+````markdown
+# [Feature/Task Name] Implementation Plan
+
+## Overview
+
+[Brief description of what we're implementing and why]
+
+## Current State Analysis
+
+[What exists now, what's missing, key constraints discovered]
+
+## Desired End State
+
+[A Specification of the desired end state after this plan is complete, and how to verify it]
+
+### Key Discoveries:
+- [Important finding with file:line reference]
+- [Pattern to follow]
+- [Constraint to work within]
+
+## What We're NOT Doing
+
+[Explicitly list out-of-scope items to prevent scope creep]
+
+## Implementation Approach
+
+[High-level strategy and reasoning]
+
+## Phase 1: [Descriptive Name]
+
+### Overview
+[What this phase accomplishes]
+
+### Changes Required:
+
+#### 1. [Component/File Group]
+**File**: `path/to/file.ext`
+**Changes**: [Summary of changes]
+
+```[language]
+// Specific code to add/modify
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Migration applies cleanly: `make migrate`
+- [ ] Unit tests pass: `make test-component`
+- [ ] Type checking passes: `npm run typecheck`
+- [ ] Linting passes: `make lint`
+- [ ] Integration tests pass: `make test-integration`
+
+#### Manual Verification:
+- [ ] Feature works as expected when tested via UI
+- [ ] Performance is acceptable under load
+- [ ] Edge case handling verified manually
+- [ ] No regressions in related features
+
+**Implementation Note**: After completing this phase and all automated verification passes, pause here for manual confirmation from the human that the manual testing was successful before proceeding to the next phase.
+
+---
+
+## Phase 2: [Descriptive Name]
+
+[Similar structure with both automated and manual success criteria...]
+
+---
+
+## Testing Strategy
+
+### Unit Tests:
+- [What to test]
+- [Key edge cases]
+
+### Integration Tests:
+- [End-to-end scenarios]
+
+### Manual Testing Steps:
+1. [Specific step to verify feature]
+2. [Another verification step]
+3. [Edge case to test manually]
+
+## Performance Considerations
+
+[Any performance implications or optimizations needed]
+
+## Migration Notes
+
+[If applicable, how to handle existing data/systems]
+
+## References
+
+- Original ticket: `thoughts/allison/tickets/eng_XXXX.md`
+- Related research: `thoughts/shared/research/[relevant].md`
+- Similar implementation: `[file:line]`
+````
+
+### Step 5: Sync and Review
+
+1. **Sync the thoughts directory**:
+   - Run `humanlayer thoughts sync` to sync the newly created plan
+   - This ensures the plan is properly indexed and available
+
+2. **Present the draft plan location**:
+   ```
+   I've created the initial implementation plan at:
+   `thoughts/shared/plans/YYYY-MM-DD-ENG-XXXX-description.md`
+
+   Please review it and let me know:
+   - Are the phases properly scoped?
+   - Are the success criteria specific enough?
+   - Any technical details that need adjustment?
+   - Missing edge cases or considerations?
+   ```
+
+3. **Iterate based on feedback** - be ready to:
+   - Add missing phases
+   - Adjust technical approach
+   - Clarify success criteria (both automated and manual)
+   - Add/remove scope items
+   - After making changes, run `humanlayer thoughts sync` again
+
+4. **Continue refining** until the user is satisfied
+
+## Important Guidelines
+
+1. **Be Skeptical**:
+   - Question vague requirements
+   - Identify potential issues early
+   - Ask "why" and "what about"
+   - Don't assume - verify with code
+
+2. **Be Interactive**:
+   - Don't write the full plan in one shot
+   - Get buy-in at each major step
+   - Allow course corrections
+   - Work collaboratively
+
+3. **Be Thorough**:
+   - Read all context files COMPLETELY before planning
+   - Research actual code patterns using parallel sub-tasks
+   - Include specific file paths and line numbers
+   - Write measurable success criteria with clear automated vs manual distinction
+   - automated steps should use `make` whenever possible - for example `make -C humanlayer-wui check` instead of `cd humanlayer-wui && bun run fmt`
+
+4. **Be Practical**:
+   - Focus on incremental, testable changes
+   - Consider migration and rollback
+   - Think about edge cases
+   - Include "what we're NOT doing"
+
+5. **Track Progress**:
+   - Use TodoWrite to track planning tasks
+   - Update todos as you complete research
+   - Mark planning tasks complete when done
+
+6. **No Open Questions in Final Plan**:
+   - If you encounter open questions during planning, STOP
+   - Research or ask for clarification immediately
+   - Do NOT write the plan with unresolved questions
+   - The implementation plan must be complete and actionable
+   - Every decision must be made before finalizing the plan
+
+## Success Criteria Guidelines
+
+**Always separate success criteria into two categories:**
+
+1. **Automated Verification** (can be run by execution agents):
+   - Commands that can be run: `make test`, `npm run lint`, etc.
+   - Specific files that should exist
+   - Code compilation/type checking
+   - Automated test suites
+
+2. **Manual Verification** (requires human testing):
+   - UI/UX functionality
+   - Performance under real conditions
+   - Edge cases that are hard to automate
+   - User acceptance criteria
+
+**Format example:**
+```markdown
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Database migration runs successfully: `make migrate`
+- [ ] All unit tests pass: `go test ./...`
+- [ ] No linting errors: `golangci-lint run`
+- [ ] API endpoint returns 200: `curl localhost:8080/api/new-endpoint`
+
+#### Manual Verification:
+- [ ] New feature appears correctly in the UI
+- [ ] Performance is acceptable with 1000+ items
+- [ ] Error messages are user-friendly
+- [ ] Feature works correctly on mobile devices
+```
+
+## Common Patterns
+
+### For Database Changes:
+- Start with schema/migration
+- Add store methods
+- Update business logic
+- Expose via API
+- Update clients
+
+### For New Features:
+- Research existing patterns first
+- Start with data model
+- Build backend logic
+- Add API endpoints
+- Implement UI last
+
+### For Refactoring:
+- Document current behavior
+- Plan incremental changes
+- Maintain backwards compatibility
+- Include migration strategy
+
+## Sub-task Spawning Best Practices
+
+When spawning research sub-tasks:
+
+1. **Spawn multiple tasks in parallel** for efficiency
+2. **Each task should be focused** on a specific area
+3. **Provide detailed instructions** including:
+   - Exactly what to search for
+   - Which directories to focus on
+   - What information to extract
+   - Expected output format
+4. **Be EXTREMELY specific about directories**:
+   - If the ticket mentions "WUI", specify `humanlayer-wui/` directory
+   - If it mentions "daemon", specify `hld/` directory
+   - Never use generic terms like "UI" when you mean "WUI"
+   - Include the full path context in your prompts
+5. **Specify read-only tools** to use
+6. **Request specific file:line references** in responses
+7. **Wait for all tasks to complete** before synthesizing
+8. **Verify sub-task results**:
+   - If a sub-task returns unexpected results, spawn follow-up tasks
+   - Cross-check findings against the actual codebase
+   - Don't accept results that seem incorrect
+
+Example of spawning multiple tasks:
+```python
+# Spawn these tasks concurrently:
+tasks = [
+    Task("Research database schema", db_research_prompt),
+    Task("Find API patterns", api_research_prompt),
+    Task("Investigate UI components", ui_research_prompt),
+    Task("Check test patterns", test_research_prompt)
+]
+```
+
+## Example Interaction Flow
+
+```
+User: /create_plan
+Assistant: I'll help you create a detailed implementation plan...
+
+User: We need to add parent-child tracking for Codex sub-tasks. See thoughts/allison/tickets/eng_1478.md
+Assistant: Let me read that ticket file completely first...
+
+[Reads file fully]
+
+Based on the ticket, I understand we need to track parent-child relationships for Codex sub-task events in the hld daemon. Before I start planning, I have some questions...
+
+[Interactive process continues...]
+```

--- a/.agents/skills/source-command-debug/SKILL.md
+++ b/.agents/skills/source-command-debug/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: "source-command-debug"
+description: "Debug issues by investigating logs, database state, and git history"
+---
+
+# source-command-debug
+
+Use this skill when the user asks to run the migrated source command `debug`.
+
+## Command Template
+
+# Debug
+
+You are tasked with helping debug issues during manual testing or implementation. This command allows you to investigate problems by examining logs, database state, and git history without editing files. Think of this as a way to bootstrap a debugging session without using the primary window's context.
+
+## Initial Response
+
+When invoked WITH a plan/ticket file:
+```
+I'll help debug issues with [file name]. Let me understand the current state.
+
+What specific problem are you encountering?
+- What were you trying to test/implement?
+- What went wrong?
+- Any error messages?
+
+I'll investigate the logs, database, and git state to help figure out what's happening.
+```
+
+When invoked WITHOUT parameters:
+```
+I'll help debug your current issue.
+
+Please describe what's going wrong:
+- What are you working on?
+- What specific problem occurred?
+- When did it last work?
+
+I can investigate logs, database state, and recent changes to help identify the issue.
+```
+
+## Environment Information
+
+You have access to these key locations and tools:
+
+**Logs** (automatically created by `make daemon` and `make wui`):
+- MCP logs: `~/.humanlayer/logs/mcp-Codex-approvals-*.log`
+- Combined WUI/Daemon logs: `~/.humanlayer/logs/wui-${BRANCH_NAME}/codelayer.log`
+- First line shows: `[timestamp] starting [service] in [directory]`
+
+**Database**:
+- Location: `~/.humanlayer/daemon-{BRANCH_NAME}.db`
+- SQLite database with sessions, events, approvals, etc.
+- Can query directly with `sqlite3`
+
+**Git State**:
+- Check current branch, recent commits, uncommitted changes
+- Similar to how `commit` and `describe_pr` commands work
+
+**Service Status**:
+- Check if daemon is running: `ps aux | grep hld`
+- Check if WUI is running: `ps aux | grep wui`
+- Socket exists: `~/.humanlayer/daemon.sock`
+
+## Process Steps
+
+### Step 1: Understand the Problem
+
+After the user describes the issue:
+
+1. **Read any provided context** (plan or ticket file):
+   - Understand what they're implementing/testing
+   - Note which phase or step they're on
+   - Identify expected vs actual behavior
+
+2. **Quick state check**:
+   - Current git branch and recent commits
+   - Any uncommitted changes
+   - When the issue started occurring
+
+### Step 2: Investigate the Issue
+
+Spawn parallel Task agents for efficient investigation:
+
+```
+Task 1 - Check Recent Logs:
+Find and analyze the most recent logs for errors:
+1. Find latest daemon log: ls -t ~/.humanlayer/logs/daemon-*.log | head -1
+2. Find latest WUI log: ls -t ~/.humanlayer/logs/wui-*.log | head -1
+3. Search for errors, warnings, or issues around the problem timeframe
+4. Note the working directory (first line of log)
+5. Look for stack traces or repeated errors
+Return: Key errors/warnings with timestamps
+```
+
+```
+Task 2 - Database State:
+Check the current database state:
+1. Connect to database: sqlite3 ~/.humanlayer/daemon.db
+2. Check schema: .tables and .schema for relevant tables
+3. Query recent data:
+   - SELECT * FROM sessions ORDER BY created_at DESC LIMIT 5;
+   - SELECT * FROM conversation_events WHERE created_at > datetime('now', '-1 hour');
+   - Other queries based on the issue
+4. Look for stuck states or anomalies
+Return: Relevant database findings
+```
+
+```
+Task 3 - Git and File State:
+Understand what changed recently:
+1. Check git status and current branch
+2. Look at recent commits: git log --oneline -10
+3. Check uncommitted changes: git diff
+4. Verify expected files exist
+5. Look for any file permission issues
+Return: Git state and any file issues
+```
+
+### Step 3: Present Findings
+
+Based on the investigation, present a focused debug report:
+
+```markdown
+## Debug Report
+
+### What's Wrong
+[Clear statement of the issue based on evidence]
+
+### Evidence Found
+
+**From Logs** (`~/.humanlayer/logs/`):
+- [Error/warning with timestamp]
+- [Pattern or repeated issue]
+
+**From Database**:
+```sql
+-- Relevant query and result
+[Finding from database]
+```
+
+**From Git/Files**:
+- [Recent changes that might be related]
+- [File state issues]
+
+### Root Cause
+[Most likely explanation based on evidence]
+
+### Next Steps
+
+1. **Try This First**:
+   ```bash
+   [Specific command or action]
+   ```
+
+2. **If That Doesn't Work**:
+   - Restart services: `make daemon` and `make wui`
+   - Check browser console for WUI errors
+   - Run with debug: `HUMANLAYER_DEBUG=true make daemon`
+
+### Can't Access?
+Some issues might be outside my reach:
+- Browser console errors (F12 in browser)
+- MCP server internal state
+- System-level issues
+
+Would you like me to investigate something specific further?
+```
+
+## Important Notes
+
+- **Focus on manual testing scenarios** - This is for debugging during implementation
+- **Always require problem description** - Can't debug without knowing what's wrong
+- **Read files completely** - No limit/offset when reading context
+- **Think like `commit` or `describe_pr`** - Understand git state and changes
+- **Guide back to user** - Some issues (browser console, MCP internals) are outside reach
+- **No file editing** - Pure investigation only
+
+## Quick Reference
+
+**Find Latest Logs**:
+```bash
+ls -t ~/.humanlayer/logs/daemon-*.log | head -1
+ls -t ~/.humanlayer/logs/wui-*.log | head -1
+```
+
+**Database Queries**:
+```bash
+sqlite3 ~/.humanlayer/daemon.db ".tables"
+sqlite3 ~/.humanlayer/daemon.db ".schema sessions"
+sqlite3 ~/.humanlayer/daemon.db "SELECT * FROM sessions ORDER BY created_at DESC LIMIT 5;"
+```
+
+**Service Check**:
+```bash
+ps aux | grep hld     # Is daemon running?
+ps aux | grep wui     # Is WUI running?
+```
+
+**Git State**:
+```bash
+git status
+git log --oneline -10
+git diff
+```
+
+Remember: This command helps you investigate without burning the primary window's context. Perfect for when you hit an issue during manual testing and need to dig into logs, database, or git state.

--- a/.agents/skills/source-command-ff-commit/SKILL.md
+++ b/.agents/skills/source-command-ff-commit/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: "source-command-ff-commit"
+description: "Create git commits without Codex attribution"
+---
+
+# source-command-ff-commit
+
+Use this skill when the user asks to run the migrated source command `ff_commit`.
+
+## Command Template
+
+# Commit Changes
+
+You are tasked with creating git commits for the changes made during this session.
+
+**CRITICAL: Execute commits immediately - do NOT ask for confirmation.**
+
+## Process:
+
+1. **Analyze changes:**
+   - Run `git status` to see current changes
+   - Run `git diff` to understand the modifications
+   - Consider whether changes should be one commit or multiple logical commits
+
+2. **Plan your commit(s):**
+   - Identify which files belong together
+   - Draft clear, descriptive commit messages
+   - Use imperative mood in commit messages
+   - Focus on why the changes were made, not just what
+
+3. **Execute commits:**
+   - Use `git add` with specific files (never use `-A` or `.`)
+   - Create commits with your planned messages
+   - Show the result with `git log --oneline -n [number]`
+
+## Important:
+- **NEVER add co-author information or Codex attribution**
+- Commits should be authored solely by the user
+- Do not include any "Generated with Codex" messages
+- Do not add "Co-Authored-By" lines
+- Write commit messages as if the user wrote them
+
+## Remember:
+- You have the full context of what was done in this session
+- Group related changes together
+- Keep commits focused and atomic when possible
+- The user trusts your judgment - they asked you to commit

--- a/.agents/skills/source-command-ff-create-handoff/SKILL.md
+++ b/.agents/skills/source-command-ff-create-handoff/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: "source-command-ff-create-handoff"
+description: "Create handoff document for transferring work to another session"
+---
+
+# source-command-ff-create-handoff
+
+Use this skill when the user asks to run the migrated source command `ff_create_handoff`.
+
+## Command Template
+
+# Create Handoff
+
+You are tasked with writing a handoff document to hand off your work to another agent in a new session. You will create a handoff document that is thorough, but also **concise**. The goal is to compact and summarize your context without losing any of the key details of what you're working on.
+
+
+## Process
+### 1. Filepath & Metadata
+Use the following information to understand how to create your document:
+    - create your file under `thoughts/shared/handoffs/ENG-XXXX/YYYY-MM-DD_HH-MM-SS_ENG-ZZZZ_description.md`, where:
+        - YYYY-MM-DD is today's date
+        - HH-MM-SS is the hours, minutes and seconds based on the current time, in 24-hour format (i.e. use `13:00` for `1:00 pm`)
+        - ENG-XXXX is the ticket number (replace with `general` if no ticket)
+        - ENG-ZZZZ is the ticket number (omit if no ticket)
+        - description is a brief kebab-case description
+    - Run the `scripts/spec_metadata.sh` script to generate all relevant metadata
+    - Examples:
+        - With ticket: `2025-01-08_13-55-22_ENG-2166_create-context-compaction.md`
+        - Without ticket: `2025-01-08_13-55-22_create-context-compaction.md`
+
+### 2. Handoff writing.
+using the above conventions, write your document. use the defined filepath, and the following YAML frontmatter pattern. Use the metadata gathered in step 1, Structure the document with YAML frontmatter followed by content:
+
+Use the following template structure:
+```markdown
+---
+date: [Current date and time with timezone in ISO format]
+researcher: [Researcher name from thoughts status]
+git_commit: [Current commit hash]
+branch: [Current branch name]
+repository: [Repository name]
+topic: "[Feature/Task Name] Implementation Strategy"
+tags: [implementation, strategy, relevant-component-names]
+status: complete
+last_updated: [Current date in YYYY-MM-DD format]
+last_updated_by: [Researcher name]
+type: implementation_strategy
+---
+
+# Handoff: ENG-XXXX {very concise description}
+
+## Task(s)
+{description of the task(s) that you were working on, along with the status of each (completed, work in progress, planned/discussed). If you are working on an implementation plan, make sure to call out which phase you are on. Make sure to reference the plan document and/or research document(s) you are working from that were provided to you at the beginning of the session, if applicable.}
+
+## Critical References
+{List any critical specification documents, architectural decisions, or design docs that must be followed. Include only 2-3 most important file paths. Leave blank if none.}
+
+## Recent changes
+{describe recent changes made to the codebase that you made in line:file syntax}
+
+## Learnings
+{describe important things that you learned - e.g. patterns, root causes of bugs, or other important pieces of information someone that is picking up your work after you should know. consider listing explicit file paths.}
+
+## Artifacts
+{ an exhaustive list of artifacts you produced or updated as filepaths and/or file:line references - e.g. paths to feature documents, implementation plans, etc that should be read in order to resume your work.}
+
+## Action Items & Next Steps
+{ a list of action items and next steps for the next agent to accomplish based on your tasks and their statuses}
+
+## Other Notes
+{ other notes, references, or useful information - e.g. where relevant sections of the codebase are, where relevant documents are, or other important things you leanrned that you want to pass on but that don't fall into the above categories}
+```
+---
+
+### 3. Approve and Sync
+Run `humanlayer thoughts sync` to save the document.
+
+Once this is completed, you should respond to the user with the template between <template_response></template_response> XML tags. do NOT include the tags in your response.
+
+<template_response>
+Handoff created and synced! You can resume from this handoff in a new session with the following command:
+
+```bash
+/ff_resume_handoff path/to/handoff.md
+```
+</template_response>
+
+for example (between <example_response></example_response> XML tags - do NOT include these tags in your actual response to the user)
+
+<example_response>
+Handoff created and synced! You can resume from this handoff in a new session with the following command:
+
+```bash
+/ff_resume_handoff thoughts/shared/handoffs/ENG-2166/2025-01-08_13-44-55_ENG-2166_create-context-compaction.md
+```
+</example_response>
+
+---
+##.  Additional Notes & Instructions
+- **more information, not less**. This is a guideline that defines the minimum of what a handoff should be. Always feel free to include more information if necessary.
+- **be thorough and precise**. include both top-level objectives, and lower-level details as necessary.
+- **avoid excessive code snippets**. While a brief snippet to describe some key change is important, avoid large code blocks or diffs; do not include one unless it's necessary (e.g. pertains to an error you're debugging). Prefer using `/path/to/file.ext:line` references that an agent can follow later when it's ready, e.g. `packages/dashboard/src/app/dashboard/page.tsx:12-24`

--- a/.agents/skills/source-command-ff-create-plan/SKILL.md
+++ b/.agents/skills/source-command-ff-create-plan/SKILL.md
@@ -1,0 +1,455 @@
+---
+name: "source-command-ff-create-plan"
+description: "Create detailed implementation plans through interactive research and iteration"
+---
+
+# source-command-ff-create-plan
+
+Use this skill when the user asks to run the migrated source command `ff_create_plan`.
+
+## Command Template
+
+# Implementation Plan
+
+You are tasked with creating detailed implementation plans through an interactive, iterative process. You should be skeptical, thorough, and work collaboratively with the user to produce high-quality technical specifications.
+
+## Initial Response
+
+When this command is invoked:
+
+1. **Check if parameters were provided**:
+   - If a file path or ticket reference was provided as a parameter, skip the default message
+   - Immediately read any provided files FULLY
+   - Begin the research process
+
+2. **If no parameters provided**, respond with:
+```
+I'll help you create a detailed implementation plan. Let me start by understanding what we're building.
+
+Please provide:
+1. The task/ticket description (or reference to a ticket file)
+2. Any relevant context, constraints, or specific requirements
+3. Links to related research or previous implementations
+
+I'll analyze this information and work with you to create a comprehensive plan.
+
+Tip: You can also invoke this command with a ticket file directly: `/ff_create_plan thoughts/allison/tickets/eng_1234.md`
+For deeper analysis, try: `/ff_create_plan think deeply about thoughts/allison/tickets/eng_1234.md`
+```
+
+Then wait for the user's input.
+
+## Process Steps
+
+### Step 1: Context Gathering & Initial Analysis
+
+1. **Read all mentioned files immediately and FULLY**:
+   - Ticket files (e.g., `thoughts/allison/tickets/eng_1234.md`)
+   - Research documents
+   - Related implementation plans
+   - Any JSON/data files mentioned
+   - **IMPORTANT**: Use the Read tool WITHOUT limit/offset parameters to read entire files
+   - **CRITICAL**: DO NOT spawn sub-tasks before reading these files yourself in the main context
+   - **NEVER** read files partially - if a file is mentioned, read it completely
+
+2. **Spawn initial research tasks to gather context**:
+   Before asking the user any questions, use specialized agents to research in parallel:
+
+   - Use the **codebase-locator** agent to find all files related to the ticket/task
+   - Use the **codebase-analyzer** agent to understand how the current implementation works
+   - If relevant, use the **thoughts-locator** agent to find any existing thoughts documents about this feature
+   - If a Linear ticket is mentioned, use the **linear-ticket-reader** agent to get full details
+
+   These agents will:
+   - Find relevant source files, configs, and tests
+   - Identify the specific directories to focus on (e.g., if WUI is mentioned, they'll focus on humanlayer-wui/)
+   - Trace data flow and key functions
+   - Return detailed explanations with file:line references
+
+3. **Read all files identified by research tasks**:
+   - After research tasks complete, read ALL files they identified as relevant
+   - Read them FULLY into the main context
+   - This ensures you have complete understanding before proceeding
+
+4. **Analyze and verify understanding**:
+   - Cross-reference the ticket requirements with actual code
+   - Identify any discrepancies or misunderstandings
+   - Note assumptions that need verification
+   - Determine true scope based on codebase reality
+
+5. **Present informed understanding and focused questions**:
+   ```
+   Based on the ticket and my research of the codebase, I understand we need to [accurate summary].
+
+   I've found that:
+   - [Current implementation detail with file:line reference]
+   - [Relevant pattern or constraint discovered]
+   - [Potential complexity or edge case identified]
+
+   Questions that my research couldn't answer:
+   - [Specific technical question that requires human judgment]
+   - [Business logic clarification]
+   - [Design preference that affects implementation]
+   ```
+
+   Only ask questions that you genuinely cannot answer through code investigation.
+
+### Step 2: Research & Discovery
+
+After getting initial clarifications:
+
+1. **If the user corrects any misunderstanding**:
+   - DO NOT just accept the correction
+   - Spawn new research tasks to verify the correct information
+   - Read the specific files/directories they mention
+   - Only proceed once you've verified the facts yourself
+
+2. **Create a research todo list** using TodoWrite to track exploration tasks
+
+3. **Spawn parallel sub-tasks for comprehensive research**:
+   - Create multiple Task agents to research different aspects concurrently
+   - Use the right agent for each type of research:
+
+   **For deeper investigation:**
+   - **codebase-locator** - To find more specific files (e.g., "find all files that handle [specific component]")
+   - **codebase-analyzer** - To understand implementation details (e.g., "analyze how [system] works")
+   - **codebase-pattern-finder** - To find similar features we can model after
+
+   **For historical context:**
+   - **thoughts-locator** - To find any research, plans, or decisions about this area
+   - **thoughts-analyzer** - To extract key insights from the most relevant documents
+
+   **For related tickets:**
+   - **linear-searcher** - To find similar issues or past implementations
+
+   Each agent knows how to:
+   - Find the right files and code patterns
+   - Identify conventions and patterns to follow
+   - Look for integration points and dependencies
+   - Return specific file:line references
+   - Find tests and examples
+
+3. **Wait for ALL sub-tasks to complete** before proceeding
+
+4. **Present findings and design options**:
+   ```
+   Based on my research, here's what I found:
+
+   **Current State:**
+   - [Key discovery about existing code]
+   - [Pattern or convention to follow]
+
+   **Design Options:**
+   1. [Option A] - [pros/cons]
+   2. [Option B] - [pros/cons]
+
+   **Open Questions:**
+   - [Technical uncertainty]
+   - [Design decision needed]
+
+   Which approach aligns best with your vision?
+   ```
+
+### Step 3: Plan Structure Development
+
+Once aligned on approach:
+
+1. **Create initial plan outline**:
+   ```
+   Here's my proposed plan structure:
+
+   ## Overview
+   [1-2 sentence summary]
+
+   ## Implementation Phases:
+   1. [Phase name] - [what it accomplishes]
+   2. [Phase name] - [what it accomplishes]
+   3. [Phase name] - [what it accomplishes]
+
+   Does this phasing make sense? Should I adjust the order or granularity?
+   ```
+
+2. **Get feedback on structure** before writing details
+
+### Step 4: Detailed Plan Writing
+
+After structure approval:
+
+1. **Write the plan** to `thoughts/shared/plans/YYYY-MM-DD-ENG-XXXX-description.md`
+   - Format: `YYYY-MM-DD-ENG-XXXX-description.md` where:
+     - YYYY-MM-DD is today's date
+     - ENG-XXXX is the ticket number (omit if no ticket)
+     - description is a brief kebab-case description
+   - Examples:
+     - With ticket: `2025-01-08-ENG-1478-parent-child-tracking.md`
+     - Without ticket: `2025-01-08-improve-error-handling.md`
+2. **Use this template structure**:
+
+````markdown
+# [Feature/Task Name] Implementation Plan
+
+## Overview
+
+[Brief description of what we're implementing and why]
+
+## Current State Analysis
+
+[What exists now, what's missing, key constraints discovered]
+
+## Desired End State
+
+[A Specification of the desired end state after this plan is complete, and how to verify it]
+
+### Key Discoveries:
+- [Important finding with file:line reference]
+- [Pattern to follow]
+- [Constraint to work within]
+
+## What We're NOT Doing
+
+[Explicitly list out-of-scope items to prevent scope creep]
+
+## Implementation Approach
+
+[High-level strategy and reasoning]
+
+## Phase 1: [Descriptive Name]
+
+### Overview
+[What this phase accomplishes]
+
+### Changes Required:
+
+#### 1. [Component/File Group]
+**File**: `path/to/file.ext`
+**Changes**: [Summary of changes]
+
+```[language]
+// Specific code to add/modify
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Migration applies cleanly: `make migrate`
+- [ ] Unit tests pass: `make test-component`
+- [ ] Type checking passes: `npm run typecheck`
+- [ ] Linting passes: `make lint`
+- [ ] Integration tests pass: `make test-integration`
+
+#### Manual Verification:
+- [ ] Feature works as expected when tested via UI
+- [ ] Performance is acceptable under load
+- [ ] Edge case handling verified manually
+- [ ] No regressions in related features
+
+**Implementation Note**: After completing this phase and all automated verification passes, pause here for manual confirmation from the human that the manual testing was successful before proceeding to the next phase.
+
+---
+
+## Phase 2: [Descriptive Name]
+
+[Similar structure with both automated and manual success criteria...]
+
+---
+
+## Testing Strategy
+
+### Unit Tests:
+- [What to test]
+- [Key edge cases]
+
+### Integration Tests:
+- [End-to-end scenarios]
+
+### Manual Testing Steps:
+1. [Specific step to verify feature]
+2. [Another verification step]
+3. [Edge case to test manually]
+
+## Performance Considerations
+
+[Any performance implications or optimizations needed]
+
+## Migration Notes
+
+[If applicable, how to handle existing data/systems]
+
+## References
+
+- Original ticket: `thoughts/allison/tickets/eng_XXXX.md`
+- Related research: `thoughts/shared/research/[relevant].md`
+- Similar implementation: `[file:line]`
+````
+
+### Step 5: Sync and Review
+
+1. **Sync the thoughts directory**:
+   - Run `humanlayer thoughts sync` to sync the newly created plan
+   - This ensures the plan is properly indexed and available
+
+2. **Present the draft plan location**:
+   ```
+   I've created the initial implementation plan at:
+   `thoughts/shared/plans/YYYY-MM-DD-ENG-XXXX-description.md`
+
+   Please review it and let me know:
+   - Are the phases properly scoped?
+   - Are the success criteria specific enough?
+   - Any technical details that need adjustment?
+   - Missing edge cases or considerations?
+   ```
+
+3. **Iterate based on feedback** - be ready to:
+   - Add missing phases
+   - Adjust technical approach
+   - Clarify success criteria (both automated and manual)
+   - Add/remove scope items
+   - After making changes, run `humanlayer thoughts sync` again
+
+4. **Continue refining** until the user is satisfied
+
+## Important Guidelines
+
+1. **Be Skeptical**:
+   - Question vague requirements
+   - Identify potential issues early
+   - Ask "why" and "what about"
+   - Don't assume - verify with code
+
+2. **Be Interactive**:
+   - Don't write the full plan in one shot
+   - Get buy-in at each major step
+   - Allow course corrections
+   - Work collaboratively
+
+3. **Be Thorough**:
+   - Read all context files COMPLETELY before planning
+   - Research actual code patterns using parallel sub-tasks
+   - Include specific file paths and line numbers
+   - Write measurable success criteria with clear automated vs manual distinction
+   - automated steps should use `make` whenever possible - for example `make -C humanlayer-wui check` instead of `cd humanlayer-wui && bun run fmt`
+
+4. **Be Practical**:
+   - Focus on incremental, testable changes
+   - Consider migration and rollback
+   - Think about edge cases
+   - Include "what we're NOT doing"
+
+5. **Track Progress**:
+   - Use TodoWrite to track planning tasks
+   - Update todos as you complete research
+   - Mark planning tasks complete when done
+
+6. **No Open Questions in Final Plan**:
+   - If you encounter open questions during planning, STOP
+   - Research or ask for clarification immediately
+   - Do NOT write the plan with unresolved questions
+   - The implementation plan must be complete and actionable
+   - Every decision must be made before finalizing the plan
+
+## Success Criteria Guidelines
+
+**Always separate success criteria into two categories:**
+
+1. **Automated Verification** (can be run by execution agents):
+   - Commands that can be run: `make test`, `npm run lint`, etc.
+   - Specific files that should exist
+   - Code compilation/type checking
+   - Automated test suites
+
+2. **Manual Verification** (requires human testing):
+   - UI/UX functionality
+   - Performance under real conditions
+   - Edge cases that are hard to automate
+   - User acceptance criteria
+
+**Format example:**
+```markdown
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Database migration runs successfully: `make migrate`
+- [ ] All unit tests pass: `go test ./...`
+- [ ] No linting errors: `golangci-lint run`
+- [ ] API endpoint returns 200: `curl localhost:8080/api/new-endpoint`
+
+#### Manual Verification:
+- [ ] New feature appears correctly in the UI
+- [ ] Performance is acceptable with 1000+ items
+- [ ] Error messages are user-friendly
+- [ ] Feature works correctly on mobile devices
+```
+
+## Common Patterns
+
+### For Database Changes:
+- Start with schema/migration
+- Add store methods
+- Update business logic
+- Expose via API
+- Update clients
+
+### For New Features:
+- Research existing patterns first
+- Start with data model
+- Build backend logic
+- Add API endpoints
+- Implement UI last
+
+### For Refactoring:
+- Document current behavior
+- Plan incremental changes
+- Maintain backwards compatibility
+- Include migration strategy
+
+## Sub-task Spawning Best Practices
+
+When spawning research sub-tasks:
+
+1. **Spawn multiple tasks in parallel** for efficiency
+2. **Each task should be focused** on a specific area
+3. **Provide detailed instructions** including:
+   - Exactly what to search for
+   - Which directories to focus on
+   - What information to extract
+   - Expected output format
+4. **Be EXTREMELY specific about directories**:
+   - If the ticket mentions "WUI", specify `humanlayer-wui/` directory
+   - If it mentions "daemon", specify `hld/` directory
+   - Never use generic terms like "UI" when you mean "WUI"
+   - Include the full path context in your prompts
+5. **Specify read-only tools** to use
+6. **Request specific file:line references** in responses
+7. **Wait for all tasks to complete** before synthesizing
+8. **Verify sub-task results**:
+   - If a sub-task returns unexpected results, spawn follow-up tasks
+   - Cross-check findings against the actual codebase
+   - Don't accept results that seem incorrect
+
+Example of spawning multiple tasks:
+```python
+# Spawn these tasks concurrently:
+tasks = [
+    Task("Research database schema", db_research_prompt),
+    Task("Find API patterns", api_research_prompt),
+    Task("Investigate UI components", ui_research_prompt),
+    Task("Check test patterns", test_research_prompt)
+]
+```
+
+## Example Interaction Flow
+
+```
+User: /create_plan
+Assistant: I'll help you create a detailed implementation plan...
+
+User: We need to add parent-child tracking for Codex sub-tasks. See thoughts/allison/tickets/eng_1478.md
+Assistant: Let me read that ticket file completely first...
+
+[Reads file fully]
+
+Based on the ticket, I understand we need to track parent-child relationships for Codex sub-task events in the hld daemon. Before I start planning, I have some questions...
+
+[Interactive process continues...]
+```

--- a/.agents/skills/source-command-ff-debug/SKILL.md
+++ b/.agents/skills/source-command-ff-debug/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: "source-command-ff-debug"
+description: "Debug issues by investigating logs, database state, and git history"
+---
+
+# source-command-ff-debug
+
+Use this skill when the user asks to run the migrated source command `ff_debug`.
+
+## Command Template
+
+# Debug
+
+You are tasked with helping debug issues during manual testing or implementation. This command allows you to investigate problems by examining logs, database state, and git history without editing files. Think of this as a way to bootstrap a debugging session without using the primary window's context.
+
+## Initial Response
+
+When invoked WITH a plan/ticket file:
+```
+I'll help debug issues with [file name]. Let me understand the current state.
+
+What specific problem are you encountering?
+- What were you trying to test/implement?
+- What went wrong?
+- Any error messages?
+
+I'll investigate the logs, database, and git state to help figure out what's happening.
+```
+
+When invoked WITHOUT parameters:
+```
+I'll help debug your current issue.
+
+Please describe what's going wrong:
+- What are you working on?
+- What specific problem occurred?
+- When did it last work?
+
+I can investigate logs, database state, and recent changes to help identify the issue.
+```
+
+## Environment Information
+
+You have access to these key locations and tools:
+
+**Logs** (automatically created by `make daemon` and `make wui`):
+- MCP logs: `~/.humanlayer/logs/mcp-Codex-approvals-*.log`
+- Combined WUI/Daemon logs: `~/.humanlayer/logs/wui-${BRANCH_NAME}/codelayer.log`
+- First line shows: `[timestamp] starting [service] in [directory]`
+
+**Database**:
+- Location: `~/.humanlayer/daemon-{BRANCH_NAME}.db`
+- SQLite database with sessions, events, approvals, etc.
+- Can query directly with `sqlite3`
+
+**Git State**:
+- Check current branch, recent commits, uncommitted changes
+- Similar to how `commit` and `describe_pr` commands work
+
+**Service Status**:
+- Check if daemon is running: `ps aux | grep hld`
+- Check if WUI is running: `ps aux | grep wui`
+- Socket exists: `~/.humanlayer/daemon.sock`
+
+## Process Steps
+
+### Step 1: Understand the Problem
+
+After the user describes the issue:
+
+1. **Read any provided context** (plan or ticket file):
+   - Understand what they're implementing/testing
+   - Note which phase or step they're on
+   - Identify expected vs actual behavior
+
+2. **Quick state check**:
+   - Current git branch and recent commits
+   - Any uncommitted changes
+   - When the issue started occurring
+
+### Step 2: Investigate the Issue
+
+Spawn parallel Task agents for efficient investigation:
+
+```
+Task 1 - Check Recent Logs:
+Find and analyze the most recent logs for errors:
+1. Find latest daemon log: ls -t ~/.humanlayer/logs/daemon-*.log | head -1
+2. Find latest WUI log: ls -t ~/.humanlayer/logs/wui-*.log | head -1
+3. Search for errors, warnings, or issues around the problem timeframe
+4. Note the working directory (first line of log)
+5. Look for stack traces or repeated errors
+Return: Key errors/warnings with timestamps
+```
+
+```
+Task 2 - Database State:
+Check the current database state:
+1. Connect to database: sqlite3 ~/.humanlayer/daemon.db
+2. Check schema: .tables and .schema for relevant tables
+3. Query recent data:
+   - SELECT * FROM sessions ORDER BY created_at DESC LIMIT 5;
+   - SELECT * FROM conversation_events WHERE created_at > datetime('now', '-1 hour');
+   - Other queries based on the issue
+4. Look for stuck states or anomalies
+Return: Relevant database findings
+```
+
+```
+Task 3 - Git and File State:
+Understand what changed recently:
+1. Check git status and current branch
+2. Look at recent commits: git log --oneline -10
+3. Check uncommitted changes: git diff
+4. Verify expected files exist
+5. Look for any file permission issues
+Return: Git state and any file issues
+```
+
+### Step 3: Present Findings
+
+Based on the investigation, present a focused debug report:
+
+```markdown
+## Debug Report
+
+### What's Wrong
+[Clear statement of the issue based on evidence]
+
+### Evidence Found
+
+**From Logs** (`~/.humanlayer/logs/`):
+- [Error/warning with timestamp]
+- [Pattern or repeated issue]
+
+**From Database**:
+```sql
+-- Relevant query and result
+[Finding from database]
+```
+
+**From Git/Files**:
+- [Recent changes that might be related]
+- [File state issues]
+
+### Root Cause
+[Most likely explanation based on evidence]
+
+### Next Steps
+
+1. **Try This First**:
+   ```bash
+   [Specific command or action]
+   ```
+
+2. **If That Doesn't Work**:
+   - Restart services: `make daemon` and `make wui`
+   - Check browser console for WUI errors
+   - Run with debug: `HUMANLAYER_DEBUG=true make daemon`
+
+### Can't Access?
+Some issues might be outside my reach:
+- Browser console errors (F12 in browser)
+- MCP server internal state
+- System-level issues
+
+Would you like me to investigate something specific further?
+```
+
+## Important Notes
+
+- **Focus on manual testing scenarios** - This is for debugging during implementation
+- **Always require problem description** - Can't debug without knowing what's wrong
+- **Read files completely** - No limit/offset when reading context
+- **Think like `commit` or `describe_pr`** - Understand git state and changes
+- **Guide back to user** - Some issues (browser console, MCP internals) are outside reach
+- **No file editing** - Pure investigation only
+
+## Quick Reference
+
+**Find Latest Logs**:
+```bash
+ls -t ~/.humanlayer/logs/daemon-*.log | head -1
+ls -t ~/.humanlayer/logs/wui-*.log | head -1
+```
+
+**Database Queries**:
+```bash
+sqlite3 ~/.humanlayer/daemon.db ".tables"
+sqlite3 ~/.humanlayer/daemon.db ".schema sessions"
+sqlite3 ~/.humanlayer/daemon.db "SELECT * FROM sessions ORDER BY created_at DESC LIMIT 5;"
+```
+
+**Service Check**:
+```bash
+ps aux | grep hld     # Is daemon running?
+ps aux | grep wui     # Is WUI running?
+```
+
+**Git State**:
+```bash
+git status
+git log --oneline -10
+git diff
+```
+
+Remember: This command helps you investigate without burning the primary window's context. Perfect for when you hit an issue during manual testing and need to dig into logs, database, or git state.

--- a/.agents/skills/source-command-ff-describe-pr/SKILL.md
+++ b/.agents/skills/source-command-ff-describe-pr/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: "source-command-ff-describe-pr"
+description: "Generate comprehensive PR descriptions following repository templates"
+---
+
+# source-command-ff-describe-pr
+
+Use this skill when the user asks to run the migrated source command `ff_describe_pr`.
+
+## Command Template
+
+# Generate PR Description
+
+You are tasked with generating a comprehensive pull request description following the repository's standard template.
+
+## Steps to follow:
+
+1. **Read the PR description template:**
+   - First, check if `thoughts/shared/pr_description.md` exists
+   - If it doesn't exist, inform the user that their `humanlayer thoughts` setup is incomplete and they need to create a PR description template at `thoughts/shared/pr_description.md`
+   - Read the template carefully to understand all sections and requirements
+
+
+2. **Identify the PR to describe:**
+   - Check if the current branch has an associated PR: `gh pr view --json url,number,title,state 2>/dev/null`
+   - If no PR exists for the current branch, or if on main/master, list open PRs: `gh pr list --limit 10 --json number,title,headRefName,author`
+   - Ask the user which PR they want to describe
+
+3. **Check for existing description:**
+   - Check if `thoughts/shared/prs/{number}_description.md` already exists
+   - If it exists, read it and inform the user you'll be updating it
+   - Consider what has changed since the last description was written
+
+4. **Gather comprehensive PR information:**
+   - Get the full PR diff: `gh pr diff {number}`
+   - If you get an error about no default remote repository, instruct the user to run `gh repo set-default` and select the appropriate repository
+   - Get commit history: `gh pr view {number} --json commits`
+   - Review the base branch: `gh pr view {number} --json baseRefName`
+   - Get PR metadata: `gh pr view {number} --json url,title,number,state`
+
+5. **Analyze the changes thoroughly:** (ultrathink about the code changes, their architectural implications, and potential impacts)
+   - Read through the entire diff carefully
+   - For context, read any files that are referenced but not shown in the diff
+   - Understand the purpose and impact of each change
+   - Identify user-facing changes vs internal implementation details
+   - Look for breaking changes or migration requirements
+
+6. **Handle verification requirements:**
+   - Look for any checklist items in the "How to verify it" section of the template
+   - For each verification step:
+     - If it's a command you can run (like `make check test`, `npm test`, etc.), run it
+     - If it passes, mark the checkbox as checked: `- [x]`
+     - If it fails, keep it unchecked and note what failed: `- [ ]` with explanation
+     - If it requires manual testing (UI interactions, external services), leave unchecked and note for user
+   - Document any verification steps you couldn't complete
+
+7. **Generate the description:**
+   - Fill out each section from the template thoroughly:
+     - Answer each question/section based on your analysis
+     - Be specific about problems solved and changes made
+     - Focus on user impact where relevant
+     - Include technical details in appropriate sections
+     - Write a concise changelog entry
+   - Ensure all checklist items are addressed (checked or explained)
+
+8. **Save and sync the description:**
+   - Write the completed description to `thoughts/shared/prs/{number}_description.md`
+   - Run `humanlayer thoughts sync` to sync the thoughts directory
+   - Show the user the generated description
+
+9. **Update the PR:**
+   - Update the PR description directly: `gh pr edit {number} --body-file thoughts/shared/prs/{number}_description.md`
+   - Confirm the update was successful
+   - If any verification steps remain unchecked, remind the user to complete them before merging
+
+## Important notes:
+- This command works across different repositories - always read the local template
+- Be thorough but concise - descriptions should be scannable
+- Focus on the "why" as much as the "what"
+- Include any breaking changes or migration notes prominently
+- If the PR touches multiple components, organize the description accordingly
+- Always attempt to run verification commands when possible
+- Clearly communicate which verification steps need manual testing

--- a/.agents/skills/source-command-ff-implement-plan/SKILL.md
+++ b/.agents/skills/source-command-ff-implement-plan/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: "source-command-ff-implement-plan"
+description: "Implement technical plans from thoughts/shared/plans with verification"
+---
+
+# source-command-ff-implement-plan
+
+Use this skill when the user asks to run the migrated source command `ff_implement_plan`.
+
+## Command Template
+
+# Implement Plan
+
+You are tasked with implementing an approved technical plan from `thoughts/shared/plans/`. These plans contain phases with specific changes and success criteria.
+
+## Getting Started
+
+When given a plan path:
+- Read the plan completely and check for any existing checkmarks (- [x])
+- Read the original ticket and all files mentioned in the plan
+- **Read files fully** - never use limit/offset parameters, you need complete context
+- Think deeply about how the pieces fit together
+- Create a todo list to track your progress
+- Start implementing if you understand what needs to be done
+
+If no plan path provided, ask for one.
+
+## Implementation Philosophy
+
+Plans are carefully designed, but reality can be messy. Your job is to:
+- Follow the plan's intent while adapting to what you find
+- Implement each phase fully before moving to the next
+- Verify your work makes sense in the broader codebase context
+- Update checkboxes in the plan as you complete sections
+
+When things don't match the plan exactly, think about why and communicate clearly. The plan is your guide, but your judgment matters too.
+
+If you encounter a mismatch:
+- STOP and think deeply about why the plan can't be followed
+- Present the issue clearly:
+  ```
+  Issue in Phase [N]:
+  Expected: [what the plan says]
+  Found: [actual situation]
+  Why this matters: [explanation]
+
+  How should I proceed?
+  ```
+
+## Verification Approach
+
+After implementing a phase:
+- Run the success criteria checks (usually `make check test` covers everything)
+- Fix any issues before proceeding
+- Update your progress in both the plan and your todos
+- Check off completed items in the plan file itself using Edit
+- **Continue to the next phase immediately** - do not pause or wait for confirmation
+- Execute all phases consecutively until the plan is complete
+
+Do not check off manual testing steps - those are for human verification after implementation is complete.
+
+
+## If You Get Stuck
+
+When something isn't working as expected:
+- First, make sure you've read and understood all the relevant code
+- Consider if the codebase has evolved since the plan was written
+- Present the mismatch clearly and ask for guidance
+
+Use sub-tasks sparingly - mainly for targeted debugging or exploring unfamiliar territory.
+
+## Resuming Work
+
+If the plan has existing checkmarks:
+- Trust that completed work is done
+- Pick up from the first unchecked item
+- Verify previous work only if something seems off
+
+Remember: You're implementing a solution, not just checking boxes. Keep the end goal in mind and maintain forward momentum.

--- a/.agents/skills/source-command-ff-iterate-plan/SKILL.md
+++ b/.agents/skills/source-command-ff-iterate-plan/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: "source-command-ff-iterate-plan"
+description: "Iterate on existing implementation plans with thorough research and updates"
+---
+
+# source-command-ff-iterate-plan
+
+Use this skill when the user asks to run the migrated source command `ff_iterate_plan`.
+
+## Command Template
+
+# Iterate Implementation Plan
+
+You are tasked with updating existing implementation plans based on user feedback. You should be skeptical, thorough, and ensure changes are grounded in actual codebase reality.
+
+## Initial Response
+
+When this command is invoked:
+
+1. **Parse the input to identify**:
+   - Plan file path (e.g., `thoughts/shared/plans/2025-10-16-feature.md`)
+   - Requested changes/feedback
+
+2. **Handle different input scenarios**:
+
+   **If NO plan file provided**:
+   ```
+   I'll help you iterate on an existing implementation plan.
+
+   Which plan would you like to update? Please provide the path to the plan file (e.g., `thoughts/shared/plans/2025-10-16-feature.md`).
+
+   Tip: You can list recent plans with `ls -lt thoughts/shared/plans/ | head`
+   ```
+   Wait for user input, then re-check for feedback.
+
+   **If plan file provided but NO feedback**:
+   ```
+   I've found the plan at [path]. What changes would you like to make?
+
+   For example:
+   - "Add a phase for migration handling"
+   - "Update the success criteria to include performance tests"
+   - "Adjust the scope to exclude feature X"
+   - "Split Phase 2 into two separate phases"
+   ```
+   Wait for user input.
+
+   **If BOTH plan file AND feedback provided**:
+   - Proceed immediately to Step 1
+   - No preliminary questions needed
+
+## Process Steps
+
+### Step 1: Read and Understand Current Plan
+
+1. **Read the existing plan file COMPLETELY**:
+   - Use the Read tool WITHOUT limit/offset parameters
+   - Understand the current structure, phases, and scope
+   - Note the success criteria and implementation approach
+
+2. **Understand the requested changes**:
+   - Parse what the user wants to add/modify/remove
+   - Identify if changes require codebase research
+   - Determine scope of the update
+
+### Step 2: Research If Needed
+
+**Only spawn research tasks if the changes require new technical understanding.**
+
+If the user's feedback requires understanding new code patterns or validating assumptions:
+
+1. **Create a research todo list** using TodoWrite
+
+2. **Spawn parallel sub-tasks for research**:
+   Use the right agent for each type of research:
+
+   **For code investigation:**
+   - **codebase-locator** - To find relevant files
+   - **codebase-analyzer** - To understand implementation details
+   - **codebase-pattern-finder** - To find similar patterns
+
+   **For historical context:**
+   - **thoughts-locator** - To find related research or decisions
+   - **thoughts-analyzer** - To extract insights from documents
+
+   **Be EXTREMELY specific about directories**:
+   - If the change involves "WUI", specify `humanlayer-wui/` directory
+   - If it involves "daemon", specify `hld/` directory
+   - Include full path context in prompts
+
+3. **Read any new files identified by research**:
+   - Read them FULLY into the main context
+   - Cross-reference with the plan requirements
+
+4. **Wait for ALL sub-tasks to complete** before proceeding
+
+### Step 3: Present Understanding and Approach
+
+Before making changes, confirm your understanding:
+
+```
+Based on your feedback, I understand you want to:
+- [Change 1 with specific detail]
+- [Change 2 with specific detail]
+
+My research found:
+- [Relevant code pattern or constraint]
+- [Important discovery that affects the change]
+
+I plan to update the plan by:
+1. [Specific modification to make]
+2. [Another modification]
+
+Does this align with your intent?
+```
+
+Get user confirmation before proceeding.
+
+### Step 4: Update the Plan
+
+1. **Make focused, precise edits** to the existing plan:
+   - Use the Edit tool for surgical changes
+   - Maintain the existing structure unless explicitly changing it
+   - Keep all file:line references accurate
+   - Update success criteria if needed
+
+2. **Ensure consistency**:
+   - If adding a new phase, ensure it follows the existing pattern
+   - If modifying scope, update "What We're NOT Doing" section
+   - If changing approach, update "Implementation Approach" section
+   - Maintain the distinction between automated vs manual success criteria
+
+3. **Preserve quality standards**:
+   - Include specific file paths and line numbers for new content
+   - Write measurable success criteria
+   - Use `make` commands for automated verification
+   - Keep language clear and actionable
+
+### Step 5: Sync and Review
+
+1. **Sync the updated plan**:
+   - Run `humanlayer thoughts sync`
+   - This ensures changes are properly indexed
+
+2. **Present the changes made**:
+   ```
+   I've updated the plan at `thoughts/shared/plans/[filename].md`
+
+   Changes made:
+   - [Specific change 1]
+   - [Specific change 2]
+
+   The updated plan now:
+   - [Key improvement]
+   - [Another improvement]
+
+   Would you like any further adjustments?
+   ```
+
+3. **Be ready to iterate further** based on feedback
+
+## Important Guidelines
+
+1. **Be Skeptical**:
+   - Don't blindly accept change requests that seem problematic
+   - Question vague feedback - ask for clarification
+   - Verify technical feasibility with code research
+   - Point out potential conflicts with existing plan phases
+
+2. **Be Surgical**:
+   - Make precise edits, not wholesale rewrites
+   - Preserve good content that doesn't need changing
+   - Only research what's necessary for the specific changes
+   - Don't over-engineer the updates
+
+3. **Be Thorough**:
+   - Read the entire existing plan before making changes
+   - Research code patterns if changes require new technical understanding
+   - Ensure updated sections maintain quality standards
+   - Verify success criteria are still measurable
+
+4. **Be Interactive**:
+   - Confirm understanding before making changes
+   - Show what you plan to change before doing it
+   - Allow course corrections
+   - Don't disappear into research without communicating
+
+5. **Track Progress**:
+   - Use TodoWrite to track update tasks if complex
+   - Update todos as you complete research
+   - Mark tasks complete when done
+
+6. **No Open Questions**:
+   - If the requested change raises questions, ASK
+   - Research or get clarification immediately
+   - Do NOT update the plan with unresolved questions
+   - Every change must be complete and actionable
+
+## Success Criteria Guidelines
+
+When updating success criteria, always maintain the two-category structure:
+
+1. **Automated Verification** (can be run by execution agents):
+   - Commands that can be run: `make test`, `npm run lint`, etc.
+   - Prefer `make` commands: `make -C humanlayer-wui check` instead of `cd humanlayer-wui && bun run fmt`
+   - Specific files that should exist
+   - Code compilation/type checking
+
+2. **Manual Verification** (requires human testing):
+   - UI/UX functionality
+   - Performance under real conditions
+   - Edge cases that are hard to automate
+   - User acceptance criteria
+
+## Sub-task Spawning Best Practices
+
+When spawning research sub-tasks:
+
+1. **Only spawn if truly needed** - don't research for simple changes
+2. **Spawn multiple tasks in parallel** for efficiency
+3. **Each task should be focused** on a specific area
+4. **Provide detailed instructions** including:
+   - Exactly what to search for
+   - Which directories to focus on
+   - What information to extract
+   - Expected output format
+5. **Request specific file:line references** in responses
+6. **Wait for all tasks to complete** before synthesizing
+7. **Verify sub-task results** - if something seems off, spawn follow-up tasks
+
+## Example Interaction Flows
+
+**Scenario 1: User provides everything upfront**
+```
+User: /ff_iterate_plan thoughts/shared/plans/2025-10-16-feature.md - add phase for error handling
+Assistant: [Reads plan, researches error handling patterns, updates plan]
+```
+
+**Scenario 2: User provides just plan file**
+```
+User: /ff_iterate_plan thoughts/shared/plans/2025-10-16-feature.md
+Assistant: I've found the plan. What changes would you like to make?
+User: Split Phase 2 into two phases - one for backend, one for frontend
+Assistant: [Proceeds with update]
+```
+
+**Scenario 3: User provides no arguments**
+```
+User: /ff_iterate_plan
+Assistant: Which plan would you like to update? Please provide the path...
+User: thoughts/shared/plans/2025-10-16-feature.md
+Assistant: I've found the plan. What changes would you like to make?
+User: Add more specific success criteria
+Assistant: [Proceeds with update]
+```

--- a/.agents/skills/source-command-ff-linear/SKILL.md
+++ b/.agents/skills/source-command-ff-linear/SKILL.md
@@ -1,0 +1,395 @@
+---
+name: "source-command-ff-linear"
+description: "Manage Linear tickets - create, update, comment, and follow workflow patterns"
+---
+
+# source-command-ff-linear
+
+Use this skill when the user asks to run the migrated source command `ff_linear`.
+
+## Command Template
+
+# Linear - Ticket Management
+
+You are tasked with managing Linear tickets, including creating tickets from thoughts documents, updating existing tickets, and following the team's specific workflow patterns.
+
+## Initial Setup
+
+First, verify that Linear MCP tools are available by checking if any `mcp__linear__` tools exist. If not, respond:
+```
+I need access to Linear tools to help with ticket management. Please run the `/mcp` command to enable the Linear MCP server, then try again.
+```
+
+If tools are available, respond based on the user's request:
+
+### For general requests:
+```
+I can help you with Linear tickets. What would you like to do?
+1. Create a new ticket from a thoughts document
+2. Add a comment to a ticket (I'll use our conversation context)
+3. Search for tickets
+4. Update ticket status or details
+```
+
+### For specific create requests:
+```
+I'll help you create a Linear ticket from your thoughts document. Please provide:
+1. The path to the thoughts document (or topic to search for)
+2. Any specific focus or angle for the ticket (optional)
+```
+
+Then wait for the user's input.
+
+## Team Workflow & Status Progression
+
+The team follows a specific workflow to ensure alignment before code implementation:
+
+1. **Triage** → All new tickets start here for initial review
+2. **Spec Needed** → More detail is needed - problem to solve and solution outline necessary
+3. **Research Needed** → Ticket requires investigation before plan can be written
+4. **Research in Progress** → Active research/investigation underway
+5. **Research in Review** → Research findings under review (optional step)
+6. **Ready for Plan** → Research complete, ticket needs an implementation plan
+7. **Plan in Progress** → Actively writing the implementation plan
+8. **Plan in Review** → Plan is written and under discussion
+9. **Ready for Dev** → Plan approved, ready for implementation
+10. **In Dev** → Active development
+11. **Code Review** → PR submitted
+12. **Done** → Completed
+
+**Key principle**: Review and alignment happen at the plan stage (not PR stage) to move faster and avoid rework.
+
+## Important Conventions
+
+### URL Mapping for Thoughts Documents
+When referencing thoughts documents, always provide GitHub links using the `links` parameter:
+- `thoughts/shared/...` → `https://github.com/humanlayer/thoughts/blob/main/repos/humanlayer/shared/...`
+- `thoughts/allison/...` → `https://github.com/humanlayer/thoughts/blob/main/repos/humanlayer/allison/...`
+- `thoughts/global/...` → `https://github.com/humanlayer/thoughts/blob/main/global/...`
+
+### Default Values
+- **Status**: Always create new tickets in "Triage" status
+- **Project**: For new tickets, default to "M U L T I C L A U D E" (ID: f11c8d63-9120-4393-bfae-553da0b04fd8) unless told otherwise
+- **Priority**: Default to Medium (3) for most tasks, use best judgment or ask user
+  - Urgent (1): Critical blockers, security issues
+  - High (2): Important features with deadlines, major bugs
+  - Medium (3): Standard implementation tasks (default)
+  - Low (4): Nice-to-haves, minor improvements
+- **Links**: Use the `links` parameter to attach URLs (not just markdown links in description)
+
+### Automatic Label Assignment
+Automatically apply labels based on the ticket content:
+- **hld**: For tickets about the `hld/` directory (the daemon)
+- **wui**: For tickets about `humanlayer-wui/`
+- **meta**: For tickets about `hlyr` commands, thoughts tool, or `thoughts/` directory
+
+Note: meta is mutually exclusive with hld/wui. Tickets can have both hld and wui, but not meta with either.
+
+## Action-Specific Instructions
+
+### 1. Creating Tickets from Thoughts
+
+#### Steps to follow after receiving the request:
+
+1. **Locate and read the thoughts document:**
+   - If given a path, read the document directly
+   - If given a topic/keyword, search thoughts/ directory using Grep to find relevant documents
+   - If multiple matches found, show list and ask user to select
+   - Create a TodoWrite list to track: Read document → Analyze content → Draft ticket → Get user input → Create ticket
+
+2. **Analyze the document content:**
+   - Identify the core problem or feature being discussed
+   - Extract key implementation details or technical decisions
+   - Note any specific code files or areas mentioned
+   - Look for action items or next steps
+   - Identify what stage the idea is at (early ideation vs ready to implement)
+   - Take time to ultrathink about distilling the essence of this document into a clear problem statement and solution approach
+
+3. **Check for related context (if mentioned in doc):**
+   - If the document references specific code files, read relevant sections
+   - If it mentions other thoughts documents, quickly check them
+   - Look for any existing Linear tickets mentioned
+
+4. **Get Linear workspace context:**
+   - List teams: `mcp__linear__list_teams`
+   - If multiple teams, ask user to select one
+   - List projects for selected team: `mcp__linear__list_projects`
+
+5. **Draft the ticket summary:**
+   Present a draft to the user:
+   ```
+   ## Draft Linear Ticket
+
+   **Title**: [Clear, action-oriented title]
+
+   **Description**:
+   [2-3 sentence summary of the problem/goal]
+
+   ## Key Details
+   - [Bullet points of important details from thoughts]
+   - [Technical decisions or constraints]
+   - [Any specific requirements]
+
+   ## Implementation Notes (if applicable)
+   [Any specific technical approach or steps outlined]
+
+   ## References
+   - Source: `thoughts/[path/to/document.md]` ([View on GitHub](converted GitHub URL))
+   - Related code: [any file:line references]
+   - Parent ticket: [if applicable]
+
+   ---
+   Based on the document, this seems to be at the stage of: [ideation/planning/ready to implement]
+   ```
+
+6. **Interactive refinement:**
+   Ask the user:
+   - Does this summary capture the ticket accurately?
+   - Which project should this go in? [show list]
+   - What priority? (Default: Medium/3)
+   - Any additional context to add?
+   - Should we include more/less implementation detail?
+   - Do you want to assign it to yourself?
+
+   Note: Ticket will be created in "Triage" status by default.
+
+7. **Create the Linear ticket:**
+   ```
+   mcp__linear__create_issue with:
+   - title: [refined title]
+   - description: [final description in markdown]
+   - teamId: [selected team]
+   - projectId: [use default project from above unless user specifies]
+   - priority: [selected priority number, default 3]
+   - stateId: [Triage status ID]
+   - assigneeId: [if requested]
+   - labelIds: [apply automatic label assignment from above]
+   - links: [{url: "GitHub URL", title: "Document Title"}]
+   ```
+
+8. **Post-creation actions:**
+   - Show the created ticket URL
+   - Ask if user wants to:
+     - Add a comment with additional implementation details
+     - Create sub-tasks for specific action items
+     - Update the original thoughts document with the ticket reference
+   - If yes to updating thoughts doc:
+     ```
+     Add at the top of the document:
+     ---
+     linear_ticket: [URL]
+     created: [date]
+     ---
+     ```
+
+## Example transformations:
+
+### From verbose thoughts:
+```
+"I've been thinking about how our resumed sessions don't inherit permissions properly.
+This is causing issues where users have to re-specify everything. We should probably
+store all the config in the database and then pull it when resuming. Maybe we need
+new columns for permission_prompt_tool and allowed_tools..."
+```
+
+### To concise ticket:
+```
+Title: Fix resumed sessions to inherit all configuration from parent
+
+Description:
+
+## Problem to solve
+Currently, resumed sessions only inherit Model and WorkingDir from parent sessions,
+causing all other configuration to be lost. Users must re-specify permissions and
+settings when resuming.
+
+## Solution
+Store all session configuration in the database and automatically inherit it when
+resuming sessions, with support for explicit overrides.
+```
+
+### 2. Adding Comments and Links to Existing Tickets
+
+When user wants to add a comment to a ticket:
+
+1. **Determine which ticket:**
+   - Use context from the current conversation to identify the relevant ticket
+   - If uncertain, use `mcp__linear__get_issue` to show ticket details and confirm with user
+   - Look for ticket references in recent work discussed
+
+2. **Format comments for clarity:**
+   - Attempt to keep comments concise (~10 lines) unless more detail is needed
+   - Focus on the key insight or most useful information for a human reader
+   - Not just what was done, but what matters about it
+   - Include relevant file references with backticks and GitHub links
+
+3. **File reference formatting:**
+   - Wrap paths in backticks: `thoughts/allison/example.md`
+   - Add GitHub link after: `([View](url))`
+   - Do this for both thoughts/ and code files mentioned
+
+4. **Comment structure example:**
+   ```markdown
+   Implemented retry logic in webhook handler to address rate limit issues.
+
+   Key insight: The 429 responses were clustered during batch operations,
+   so exponential backoff alone wasn't sufficient - added request queuing.
+
+   Files updated:
+   - `hld/webhooks/handler.go` ([GitHub](link))
+   - `thoughts/shared/rate_limit_analysis.md` ([GitHub](link))
+   ```
+
+5. **Handle links properly:**
+   - If adding a link with a comment: Update the issue with the link AND mention it in the comment
+   - If only adding a link: Still create a comment noting what link was added for posterity
+   - Always add links to the issue itself using the `links` parameter
+
+6. **For comments with links:**
+   ```
+   # First, update the issue with the link
+   mcp__linear__update_issue with:
+   - id: [ticket ID]
+   - links: [existing links + new link with proper title]
+
+   # Then, create the comment mentioning the link
+   mcp__linear__create_comment with:
+   - issueId: [ticket ID]
+   - body: [formatted comment with key insights and file references]
+   ```
+
+7. **For links only:**
+   ```
+   # Update the issue with the link
+   mcp__linear__update_issue with:
+   - id: [ticket ID]
+   - links: [existing links + new link with proper title]
+
+   # Add a brief comment for posterity
+   mcp__linear__create_comment with:
+   - issueId: [ticket ID]
+   - body: "Added link: `path/to/document.md` ([View](url))"
+   ```
+
+### 3. Searching for Tickets
+
+When user wants to find tickets:
+
+1. **Gather search criteria:**
+   - Query text
+   - Team/Project filters
+   - Status filters
+   - Date ranges (createdAt, updatedAt)
+
+2. **Execute search:**
+   ```
+   mcp__linear__list_issues with:
+   - query: [search text]
+   - teamId: [if specified]
+   - projectId: [if specified]
+   - stateId: [if filtering by status]
+   - limit: 20
+   ```
+
+3. **Present results:**
+   - Show ticket ID, title, status, assignee
+   - Group by project if multiple projects
+   - Include direct links to Linear
+
+### 4. Updating Ticket Status
+
+When moving tickets through the workflow:
+
+1. **Get current status:**
+   - Fetch ticket details
+   - Show current status in workflow
+
+2. **Suggest next status:**
+   - Triage → Spec Needed (lacks detail/problem statement)
+   - Spec Needed → Research Needed (once problem/solution outlined)
+   - Research Needed → Research in Progress (starting research)
+   - Research in Progress → Research in Review (optional, can skip to Ready for Plan)
+   - Research in Review → Ready for Plan (research approved)
+   - Ready for Plan → Plan in Progress (starting to write plan)
+   - Plan in Progress → Plan in Review (plan written)
+   - Plan in Review → Ready for Dev (plan approved)
+   - Ready for Dev → In Dev (work started)
+
+3. **Update with context:**
+   ```
+   mcp__linear__update_issue with:
+   - id: [ticket ID]
+   - stateId: [new status ID]
+   ```
+
+   Consider adding a comment explaining the status change.
+
+## Important Notes
+
+- Tag users in descriptions and comments using `@[name](ID)` format, e.g., `@[dex](16765c85-2286-4c0f-ab49-0d4d79222ef5)`
+- Keep tickets concise but complete - aim for scannable content
+- All tickets should include a clear "problem to solve" - if the user asks for a ticket and only gives implementation details, you MUST ask "To write a good ticket, please explain the problem you're trying to solve from a user perspective"
+- Focus on the "what" and "why", include "how" only if well-defined
+- Always preserve links to source material using the `links` parameter
+- Don't create tickets from early-stage brainstorming unless requested
+- Use proper Linear markdown formatting
+- Include code references as: `path/to/file.ext:linenum`
+- Ask for clarification rather than guessing project/status
+- Remember that Linear descriptions support full markdown including code blocks
+- Always use the `links` parameter for external URLs (not just markdown links)
+- remember - you must get a "Problem to solve"!
+
+## Comment Quality Guidelines
+
+When creating comments, focus on extracting the **most valuable information** for a human reader:
+
+- **Key insights over summaries**: What's the "aha" moment or critical understanding?
+- **Decisions and tradeoffs**: What approach was chosen and what it enables/prevents
+- **Blockers resolved**: What was preventing progress and how it was addressed
+- **State changes**: What's different now and what it means for next steps
+- **Surprises or discoveries**: Unexpected findings that affect the work
+
+Avoid:
+- Mechanical lists of changes without context
+- Restating what's obvious from code diffs
+- Generic summaries that don't add value
+
+Remember: The goal is to help a future reader (including yourself) quickly understand what matters about this update.
+
+## Commonly Used IDs
+
+### Engineering Team
+- **Team ID**: `6b3b2115-efd4-4b83-8463-8160842d2c84`
+
+### Label IDs
+- **bug**: `ff23dde3-199b-421e-904c-4b9f9b3d452c`
+- **hld**: `d28453c8-e53e-4a06-bea9-b5bbfad5f88a`
+- **meta**: `7a5abaae-f343-4f52-98b0-7987048b0cfa`
+- **wui**: `996deb94-ba0f-4375-8b01-913e81477c4b`
+
+### Workflow State IDs
+- **Triage**: `77da144d-fe13-4c3a-a53a-cfebd06c0cbe` (type: triage)
+- **spec needed**: `274beb99-bff8-4d7b-85cf-04d18affbc82` (type: unstarted)
+- **research needed**: `d0b89672-8189-45d6-b705-50afd6c94a91` (type: unstarted)
+- **research in progress**: `c41c5a23-ce25-471f-b70a-eff1dca60ffd` (type: unstarted)
+- **research in review**: `1a9363a7-3fae-42ee-a6c8-1fc714656f09` (type: unstarted)
+- **ready for plan**: `995011dd-3e36-46e5-b776-5a4628d06cc8` (type: unstarted)
+- **plan in progress**: `a52b4793-d1b6-4e5d-be79-b2254185eed0` (type: started)
+- **plan in review**: `15f56065-41ea-4d9a-ab8c-ec8e1a811a7a` (type: started)
+- **ready for dev**: `c25bae2f-856a-4718-aaa8-b469b7822f58` (type: started)
+- **in dev**: `6be18699-18d7-496e-a7c9-37d2ddefe612` (type: started)
+- **code review**: `8ca7fda1-08d4-48fb-a0cf-954246ccbe66` (type: started)
+- **Ready for Deploy**: `a3ad0b54-17bf-4ad3-b1c1-2f56c1f2515a` (type: started)
+- **Done**: `8159f431-fbc7-495f-a861-1ba12040f672` (type: completed)
+- **Backlog**: `6cf6b25a-054a-469b-9845-9bd9ab39ad76` (type: backlog)
+- **PostIts**: `a57f2ab3-c6f8-44c7-a36b-896154729338` (type: backlog)
+- **Todo**: `ddf85246-3a7c-4141-a377-09069812bbc3` (type: unstarted)
+- **Duplicate**: `2bc0e829-9853-4f76-ad34-e8732f062da2` (type: canceled)
+- **Canceled**: `14a28d0d-c6aa-4d8e-9ff2-9801d4cc7de1` (type: canceled)
+
+
+## Linear User IDs
+
+- allison: b157f9e4-8faf-4e7e-a598-dae6dec8a584
+- dex: 16765c85-2286-4c0f-ab49-0d4d79222ef5
+- sundeep: 0062104d-9351-44f5-b64c-d0b59acb516b

--- a/.agents/skills/source-command-ff-local-review/SKILL.md
+++ b/.agents/skills/source-command-ff-local-review/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: "source-command-ff-local-review"
+description: "Set up worktree for reviewing colleague's branch"
+---
+
+# source-command-ff-local-review
+
+Use this skill when the user asks to run the migrated source command `ff_local_review`.
+
+## Command Template
+
+# Local Review
+
+You are tasked with setting up a local review environment for a colleague's branch. This involves creating a worktree, setting up dependencies, and launching a new Codex session.
+
+## Process
+
+When invoked with a parameter like `gh_username:branchName`:
+
+1. **Parse the input**:
+   - Extract GitHub username and branch name from the format `username:branchname`
+   - If no parameter provided, ask for it in the format: `gh_username:branchName`
+
+2. **Extract ticket information**:
+   - Look for ticket numbers in the branch name (e.g., `eng-1696`, `ENG-1696`)
+   - Use this to create a short worktree directory name
+   - If no ticket found, use a sanitized version of the branch name
+
+3. **Set up the remote and worktree**:
+   - Check if the remote already exists using `git remote -v`
+   - If not, add it: `git remote add USERNAME git@github.com:USERNAME/humanlayer`
+   - Fetch from the remote: `git fetch USERNAME`
+   - Create worktree: `git worktree add -b BRANCHNAME ~/wt/humanlayer/SHORT_NAME USERNAME/BRANCHNAME`
+
+4. **Configure the worktree**:
+   - Copy Codex settings: `cp .Codex/settings.local.json WORKTREE/.Codex/`
+   - Run setup: `make -C WORKTREE setup`
+   - Initialize thoughts: `cd WORKTREE && humanlayer thoughts init --directory humanlayer`
+
+## Error Handling
+
+- If worktree already exists, inform the user they need to remove it first
+- If remote fetch fails, check if the username/repo exists
+- If setup fails, provide the error but continue with the launch
+
+## Example Usage
+
+```
+/ff_local_review samdickson22:sam/eng-1696-hotkey-for-yolo-mode
+```
+
+This will:
+- Add 'samdickson22' as a remote
+- Create worktree at `~/wt/humanlayer/eng-1696`
+- Set up the environment

--- a/.agents/skills/source-command-ff-oneshot-plan/SKILL.md
+++ b/.agents/skills/source-command-ff-oneshot-plan/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: "source-command-ff-oneshot-plan"
+description: "Execute ralph plan and implementation for a ticket"
+---
+
+# source-command-ff-oneshot-plan
+
+Use this skill when the user asks to run the migrated source command `ff_oneshot_plan`.
+
+## Command Template
+
+1. use SlashCommand() to call /ralph_plan with the given ticket number
+2. use SlashCommand() to call /ralph_impl with the given ticket number

--- a/.agents/skills/source-command-ff-oneshot/SKILL.md
+++ b/.agents/skills/source-command-ff-oneshot/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: "source-command-ff-oneshot"
+description: "Research ticket and launch planning session"
+---
+
+# source-command-ff-oneshot
+
+Use this skill when the user asks to run the migrated source command `ff_oneshot`.
+
+## Command Template
+
+1. use SlashCommand() to call /ralph_research with the given ticket number
+2. launch a new session with `npx humanlayer launch --model opus --dangerously-skip-permissions --dangerously-skip-permissions-timeout 14m --title "plan ENG-XXXX" "/oneshot_plan ENG-XXXX"`

--- a/.agents/skills/source-command-ff-reply-to-comments/SKILL.md
+++ b/.agents/skills/source-command-ff-reply-to-comments/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: "source-command-ff-reply-to-comments"
+description: "Reply to PR comments after addressing feedback"
+---
+
+# source-command-ff-reply-to-comments
+
+Use this skill when the user asks to run the migrated source command `ff_reply_to_comments`.
+
+## Command Template
+
+# Reply to PR Comments
+
+You are tasked with posting replies to PR comments after addressing the feedback.
+
+## When to Use
+
+This command should be used after implementing changes based on PR review feedback. It helps track which comments have been addressed and provides context to reviewers.
+
+## Steps
+
+1. **Identify the PR**:
+   - Get PR for current branch: `gh pr view --json number,title,url,state`
+   - If no PR exists, report this and stop
+
+2. **Fetch PR comments that need replies**:
+   - Get PR comments: `gh pr view --json comments --jq '.comments[] | {id: .id, author: .author.login, body: .body, replies: .replies}'`
+   - Get review comments (on specific lines): `gh api repos/{owner}/{repo}/pulls/{number}/comments --jq '.[] | {id: .id, author: .user.login, body: .body, path: .path, line: .line}'`
+
+3. **Check for existing replies**:
+   - Look for replies you've already posted to avoid duplicates
+   - Focus on comments that don't have your replies yet
+
+4. **Read the implementation context**:
+   - Read the goal file at `{run_dir}/goal.md` to understand what was implemented
+   - Review the changes made: `git diff HEAD~1` or relevant commits
+
+5. **Post replies to addressed comments**:
+
+For each comment that has been addressed:
+
+```bash
+# For general PR comments
+gh api repos/{owner}/{repo}/issues/comments/{comment_id}/replies \
+  -X POST \
+  -f body="✅ **Addressed** - {brief description of the change made}"
+
+# For review comments (line-specific)
+gh api repos/{owner}/{repo}/pulls/{number}/comments \
+  -X POST \
+  -f commit_id=$(git rev-parse HEAD) \
+  -f path="{file_path}" \
+  -f line={line_number} \
+  -f side=RIGHT \
+  -f in_reply_to={comment_id} \
+  -f body="✅ **Addressed** - {brief description of the change made}"
+```
+
+## Reply Templates
+
+Use appropriate reply based on the action taken:
+
+- **Fixed**: "✅ **Addressed** - Fixed in commit {sha}. {description of change}"
+- **Implemented**: "✅ **Addressed** - Implemented as suggested. {details}"
+- **Partially addressed**: "🔄 **Partially Addressed** - {what was done}. {what remains/why not fully addressed}"
+- **Discussed**: "💬 **Discussed** - {explanation of why the suggestion wasn't implemented}"
+- **Clarification needed**: "❓ **Needs Clarification** - {question about the feedback}"
+
+## Best Practices
+
+1. **Be specific** - Reference the actual changes made
+2. **Link commits** - Include commit SHAs when relevant
+3. **Be concise** - Keep replies brief but informative
+4. **Don't spam** - Only reply to comments you've actually addressed
+5. **Acknowledge partially** - If you can only partially address feedback, explain why
+
+## Example Workflow
+
+```bash
+# 1. Get PR number
+gh pr view --json number --jq '.number'
+
+# 2. List comments needing replies
+gh pr view --json comments --jq '.comments[] | select(.replies | length == 0) | {id: .id, author: .author.login, body: .body[:100]}'
+
+# 3. Post reply to comment
+ghtoken=$(gh auth token)
+curl -X POST \
+  -H "Authorization: token $ghtoken" \
+  -H "Accept: application/vnd.github+json" \
+  -d '{"body":"✅ **Addressed** - Fixed in latest commit. Updated the function to handle edge cases as suggested."}' \
+  https://api.github.com/repos/{owner}/{repo}/issues/comments/{comment_id}/replies
+```
+
+## Important
+
+- Always verify the PR exists before attempting to post replies
+- Handle API errors gracefully - some comments may not be reply-able
+- Don't duplicate replies - check if you've already replied
+- Respect rate limits - batch replies if there are many comments

--- a/.agents/skills/source-command-ff-research-codebase/SKILL.md
+++ b/.agents/skills/source-command-ff-research-codebase/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: "source-command-ff-research-codebase"
+description: "Document codebase as-is with thoughts directory for historical context"
+---
+
+# source-command-ff-research-codebase
+
+Use this skill when the user asks to run the migrated source command `ff_research_codebase`.
+
+## Command Template
+
+# Research Codebase
+
+You are tasked with conducting comprehensive research across the codebase to answer user questions by spawning parallel sub-agents and synthesizing their findings.
+
+## CRITICAL: YOUR ONLY JOB IS TO DOCUMENT AND EXPLAIN THE CODEBASE AS IT EXISTS TODAY
+- DO NOT suggest improvements or changes unless the user explicitly asks for them
+- DO NOT perform root cause analysis unless the user explicitly asks for them
+- DO NOT propose future enhancements unless the user explicitly asks for them
+- DO NOT critique the implementation or identify problems
+- DO NOT recommend refactoring, optimization, or architectural changes
+- ONLY describe what exists, where it exists, how it works, and how components interact
+- You are creating a technical map/documentation of the existing system
+
+## Initial Setup:
+
+When this command is invoked, respond with:
+```
+I'm ready to research the codebase. Please provide your research question or area of interest, and I'll analyze it thoroughly by exploring relevant components and connections.
+```
+
+Then wait for the user's research query.
+
+## Steps to follow after receiving the research query:
+
+1. **Read any directly mentioned files first:**
+   - If the user mentions specific files (tickets, docs, JSON), read them FULLY first
+   - **IMPORTANT**: Use the Read tool WITHOUT limit/offset parameters to read entire files
+   - **CRITICAL**: Read these files yourself in the main context before spawning any sub-tasks
+   - This ensures you have full context before decomposing the research
+
+2. **Analyze and decompose the research question:**
+   - Break down the user's query into composable research areas
+   - Take time to ultrathink about the underlying patterns, connections, and architectural implications the user might be seeking
+   - Identify specific components, patterns, or concepts to investigate
+   - Create a research plan using TodoWrite to track all subtasks
+   - Consider which directories, files, or architectural patterns are relevant
+
+3. **Spawn parallel sub-agent tasks for comprehensive research:**
+   - Create multiple Task agents to research different aspects concurrently
+   - We now have specialized agents that know how to do specific research tasks:
+
+   **For codebase research:**
+   - Use the **codebase-locator** agent to find WHERE files and components live
+   - Use the **codebase-analyzer** agent to understand HOW specific code works (without critiquing it)
+   - Use the **codebase-pattern-finder** agent to find examples of existing patterns (without evaluating them)
+
+   **IMPORTANT**: All agents are documentarians, not critics. They will describe what exists without suggesting improvements or identifying issues.
+
+   **For thoughts directory:**
+   - Use the **thoughts-locator** agent to discover what documents exist about the topic
+   - Use the **thoughts-analyzer** agent to extract key insights from specific documents (only the most relevant ones)
+
+   **For web research (only if user explicitly asks):**
+   - Use the **web-search-researcher** agent for external documentation and resources
+   - IF you use web-research agents, instruct them to return LINKS with their findings, and please INCLUDE those links in your final report
+
+   **For Linear tickets (if relevant):**
+   - Use the **linear-ticket-reader** agent to get full details of a specific ticket
+   - Use the **linear-searcher** agent to find related tickets or historical context
+
+   The key is to use these agents intelligently:
+   - Start with locator agents to find what exists
+   - Then use analyzer agents on the most promising findings to document how they work
+   - Run multiple agents in parallel when they're searching for different things
+   - Each agent knows its job - just tell it what you're looking for
+   - Don't write detailed prompts about HOW to search - the agents already know
+   - Remind agents they are documenting, not evaluating or improving
+
+4. **Wait for all sub-agents to complete and synthesize findings:**
+   - IMPORTANT: Wait for ALL sub-agent tasks to complete before proceeding
+   - Compile all sub-agent results (both codebase and thoughts findings)
+   - Prioritize live codebase findings as primary source of truth
+   - Use thoughts/ findings as supplementary historical context
+   - Connect findings across different components
+   - Include specific file paths and line numbers for reference
+   - Verify all thoughts/ paths are correct (e.g., thoughts/allison/ not thoughts/shared/ for personal files)
+   - Highlight patterns, connections, and architectural decisions
+   - Answer the user's specific questions with concrete evidence
+
+5. **Gather metadata for the research document:**
+   - Run the `hack/spec_metadata.sh` script to generate all relevant metadata
+   - Filename: `thoughts/shared/research/YYYY-MM-DD-ENG-XXXX-description.md`
+     - Format: `YYYY-MM-DD-ENG-XXXX-description.md` where:
+       - YYYY-MM-DD is today's date
+       - ENG-XXXX is the ticket number (omit if no ticket)
+       - description is a brief kebab-case description of the research topic
+     - Examples:
+       - With ticket: `2025-01-08-ENG-1478-parent-child-tracking.md`
+       - Without ticket: `2025-01-08-authentication-flow.md`
+
+6. **Generate research document:**
+   - Use the metadata gathered in step 4
+   - Structure the document with YAML frontmatter followed by content:
+     ```markdown
+     ---
+     date: [Current date and time with timezone in ISO format]
+     researcher: [Researcher name from thoughts status]
+     git_commit: [Current commit hash]
+     branch: [Current branch name]
+     repository: [Repository name]
+     topic: "[User's Question/Topic]"
+     tags: [research, codebase, relevant-component-names]
+     status: complete
+     last_updated: [Current date in YYYY-MM-DD format]
+     last_updated_by: [Researcher name]
+     ---
+
+     # Research: [User's Question/Topic]
+
+     **Date**: [Current date and time with timezone from step 4]
+     **Researcher**: [Researcher name from thoughts status]
+     **Git Commit**: [Current commit hash from step 4]
+     **Branch**: [Current branch name from step 4]
+     **Repository**: [Repository name]
+
+     ## Research Question
+     [Original user query]
+
+     ## Summary
+     [High-level documentation of what was found, answering the user's question by describing what exists]
+
+     ## Detailed Findings
+
+     ### [Component/Area 1]
+     - Description of what exists ([file.ext:line](link))
+     - How it connects to other components
+     - Current implementation details (without evaluation)
+
+     ### [Component/Area 2]
+     ...
+
+     ## Code References
+     - `path/to/file.py:123` - Description of what's there
+     - `another/file.ts:45-67` - Description of the code block
+
+     ## Architecture Documentation
+     [Current patterns, conventions, and design implementations found in the codebase]
+
+     ## Historical Context (from thoughts/)
+     [Relevant insights from thoughts/ directory with references]
+     - `thoughts/shared/something.md` - Historical decision about X
+     - `thoughts/local/notes.md` - Past exploration of Y
+     Note: Paths exclude "searchable/" even if found there
+
+     ## Related Research
+     [Links to other research documents in thoughts/shared/research/]
+
+     ## Open Questions
+     [Any areas that need further investigation]
+     ```
+
+7. **Add GitHub permalinks (if applicable):**
+   - Check if on main branch or if commit is pushed: `git branch --show-current` and `git status`
+   - If on main/master or pushed, generate GitHub permalinks:
+     - Get repo info: `gh repo view --json owner,name`
+     - Create permalinks: `https://github.com/{owner}/{repo}/blob/{commit}/{file}#L{line}`
+   - Replace local file references with permalinks in the document
+
+8. **Sync and present findings:**
+   - Run `humanlayer thoughts sync` to sync the thoughts directory
+   - Present a concise summary of findings to the user
+   - Include key file references for easy navigation
+   - Ask if they have follow-up questions or need clarification
+
+9. **Handle follow-up questions:**
+   - If the user has follow-up questions, append to the same research document
+   - Update the frontmatter fields `last_updated` and `last_updated_by` to reflect the update
+   - Add `last_updated_note: "Added follow-up research for [brief description]"` to frontmatter
+   - Add a new section: `## Follow-up Research [timestamp]`
+   - Spawn new sub-agents as needed for additional investigation
+   - Continue updating the document and syncing
+
+## Important notes:
+- Always use parallel Task agents to maximize efficiency and minimize context usage
+- Always run fresh codebase research - never rely solely on existing research documents
+- The thoughts/ directory provides historical context to supplement live findings
+- Focus on finding concrete file paths and line numbers for developer reference
+- Research documents should be self-contained with all necessary context
+- Each sub-agent prompt should be specific and focused on read-only documentation operations
+- Document cross-component connections and how systems interact
+- Include temporal context (when the research was conducted)
+- Link to GitHub when possible for permanent references
+- Keep the main agent focused on synthesis, not deep file reading
+- Have sub-agents document examples and usage patterns as they exist
+- Explore all of thoughts/ directory, not just research subdirectory
+- **CRITICAL**: You and all sub-agents are documentarians, not evaluators
+- **REMEMBER**: Document what IS, not what SHOULD BE
+- **NO RECOMMENDATIONS**: Only describe the current state of the codebase
+- **File reading**: Always read mentioned files FULLY (no limit/offset) before spawning sub-tasks
+- **Critical ordering**: Follow the numbered steps exactly
+  - ALWAYS read mentioned files first before spawning sub-tasks (step 1)
+  - ALWAYS wait for all sub-agents to complete before synthesizing (step 4)
+  - ALWAYS gather metadata before writing the document (step 5 before step 6)
+  - NEVER write the research document with placeholder values
+- **Path handling**: The thoughts/searchable/ directory contains hard links for searching
+  - Always document paths by removing ONLY "searchable/" - preserve all other subdirectories
+  - Examples of correct transformations:
+    - `thoughts/searchable/allison/old_stuff/notes.md` → `thoughts/allison/old_stuff/notes.md`
+    - `thoughts/searchable/shared/prs/123.md` → `thoughts/shared/prs/123.md`
+    - `thoughts/searchable/global/shared/templates.md` → `thoughts/global/shared/templates.md`
+  - NEVER change allison/ to shared/ or vice versa - preserve the exact directory structure
+  - This ensures paths are correct for editing and navigation
+- **Frontmatter consistency**:
+  - Always include frontmatter at the beginning of research documents
+  - Keep frontmatter fields consistent across all research documents
+  - Update frontmatter when adding follow-up research
+  - Use snake_case for multi-word field names (e.g., `last_updated`, `git_commit`)
+  - Tags should be relevant to the research topic and components studied

--- a/.agents/skills/source-command-ff-resolve-conflicts/SKILL.md
+++ b/.agents/skills/source-command-ff-resolve-conflicts/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: "source-command-ff-resolve-conflicts"
+description: "Resolve git merge or rebase conflicts interactively"
+---
+
+# source-command-ff-resolve-conflicts
+
+Use this skill when the user asks to run the migrated source command `ff_resolve_conflicts`.
+
+## Command Template
+
+# Resolve Merge Conflicts
+
+You are tasked with helping resolve git merge or rebase conflicts in the current branch.
+
+## Initial Assessment
+
+When invoked, immediately check for conflicts:
+
+1. **Detect conflict state:**
+   ```bash
+   git status --porcelain
+   ```
+   Look for files marked with `UU` (both modified), `AA` (both added), `DD` (both deleted), etc.
+
+2. **Determine operation type:**
+   - Check for `.git/MERGE_HEAD` → merge in progress
+   - Check for `.git/rebase-merge/` or `.git/rebase-apply/` → rebase in progress
+   - Neither → no conflict state (user may need to initiate merge/rebase first)
+
+3. **If no conflicts detected:**
+   ```
+   No merge or rebase conflicts detected.
+
+   To resolve conflicts, first initiate a merge or rebase:
+   - Merge: `git merge <branch>`
+   - Rebase: `git rebase <branch>`
+
+   Then run this command again when conflicts occur.
+   ```
+
+## Conflict Resolution Process
+
+### Step 1: List Conflicted Files
+
+```bash
+git diff --name-only --diff-filter=U
+```
+
+Present the list clearly:
+```
+Found X conflicted file(s):
+1. path/to/file1.go
+2. path/to/file2.ts
+...
+```
+
+### Step 2: Analyze Each Conflict
+
+For each conflicted file:
+
+1. **Read the file** to understand the conflict markers
+2. **Identify the conflict regions** (marked by `<<<<<<<`, `=======`, `>>>>>>>`)
+3. **Understand the changes:**
+   - What's in HEAD (current branch)
+   - What's in the incoming branch
+4. **Determine resolution strategy:**
+   - Keep ours (current branch)
+   - Keep theirs (incoming branch)
+   - Combine both changes
+   - Custom resolution
+
+### Step 3: Present Resolution Plan
+
+Before making changes, present a clear plan:
+
+```markdown
+## Conflict Resolution Plan
+
+### File: path/to/file.go
+
+**Conflict 1** (lines X-Y):
+- **Ours (current):** [description]
+- **Theirs (incoming):** [description]
+- **Recommended resolution:** [explanation]
+
+**Conflict 2** (lines A-B):
+...
+
+Shall I proceed with this resolution? I'll edit the files to resolve conflicts.
+```
+
+### Step 4: Resolve Conflicts
+
+After user confirmation (or proceeding with recommended resolutions):
+
+1. **Edit each file** to remove conflict markers and apply resolution
+2. **Stage resolved files:** `git add <file>`
+3. **Verify no conflicts remain:** `git diff --name-only --diff-filter=U`
+
+### Step 5: Complete the Operation
+
+Based on operation type:
+
+**For Merge:**
+```bash
+git commit
+# Git will use the merge commit message template
+```
+
+**For Rebase:**
+```bash
+git rebase --continue
+# May need to repeat if more commits have conflicts
+```
+
+## Important Guidelines
+
+1. **Always show the conflict content** before proposing resolution
+2. **Explain reasoning** for each resolution choice
+3. **Preserve intentional changes** from both sides when possible
+4. **Be conservative** - when unsure, ask the user which version to keep
+5. **Handle binary files** by asking user which version to keep (can't merge)
+6. **Check for remaining conflicts** after each file is resolved
+
+## Quick Reference
+
+**Detect conflicts:**
+```bash
+git status --porcelain | grep "^UU\|^AA\|^DD"
+```
+
+**List conflicted files:**
+```bash
+git diff --name-only --diff-filter=U
+```
+
+**Check operation type:**
+```bash
+[ -f .git/MERGE_HEAD ] && echo "merge" || ([ -d .git/rebase-merge ] || [ -d .git/rebase-apply ]) && echo "rebase"
+```
+
+**Stage resolved file:**
+```bash
+git add <file>
+```
+
+**Complete merge:**
+```bash
+git commit
+```
+
+**Complete rebase:**
+```bash
+git rebase --continue
+```
+
+**Abort if needed:**
+```bash
+git merge --abort    # for merge
+git rebase --abort   # for rebase
+```

--- a/.agents/skills/source-command-ff-resume-handoff/SKILL.md
+++ b/.agents/skills/source-command-ff-resume-handoff/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: "source-command-ff-resume-handoff"
+description: "Resume work from handoff document with context analysis and validation"
+---
+
+# source-command-ff-resume-handoff
+
+Use this skill when the user asks to run the migrated source command `ff_resume_handoff`.
+
+## Command Template
+
+# Resume work from a handoff document
+
+You are tasked with resuming work from a handoff document through an interactive process. These handoffs contain critical context, learnings, and next steps from previous work sessions that need to be understood and continued.
+
+## Initial Response
+
+When this command is invoked:
+
+1. **If the path to a handoff document was provided**:
+   - If a handoff document path was provided as a parameter, skip the default message
+   - Immediately read the handoff document FULLY
+   - Immediately read any research or plan documents that it links to under `thoughts/shared/plans` or `thoughts/shared/research`. do NOT use a sub-agent to read these critical files.
+   - Begin the analysis process by ingesting relevant context from the handoff document, reading additional files it mentions
+   - Then propose a course of action to the user and confirm, or ask for clarification on direction.
+
+2. **If a ticket number (like ENG-XXXX) was provided**:
+   - run `humanlayer thoughts sync` to ensure your `thoughts/` directory is up to date.
+   - locate the most recent handoff document for the ticket. Tickets will be located in `thoughts/shared/handoffs/ENG-XXXX` where `ENG-XXXX` is the ticket number. e.g. for `ENG-2124` the handoffs would be in `thoughts/shared/handoffs/ENG-2124/`. **List this directory's contents.**
+   - There may be zero, one or multiple files in the directory.
+   - **If there are zero files in the directory, or the directory does not exist**: tell the user: "I'm sorry, I can't seem to find that handoff document. Can you please provide me with a path to it?"
+   - **If there is only one file in the directory**: proceed with that handoff
+   - **If there are multiple files in the directory**: using the date and time specified in the file name (it will be in the format `YYYY-MM-DD_HH-MM-SS` in 24-hour time format), proceed with the _most recent_ handoff document.
+   - Immediately read the handoff document FULLY
+   - Immediately read any research or plan documents that it links to under `thoughts/shared/plans` or `thoughts/shared/research`; do NOT use a sub-agent to read these critical files.
+   - Begin the analysis process by ingesting relevant context from the handoff document, reading additional files it mentions
+   - Then propose a course of action to the user and confirm, or ask for clarification on direction.
+
+3. **If no parameters provided**, respond with:
+```
+I'll help you resume work from a handoff document. Let me find the available handoffs.
+
+Which handoff would you like to resume from?
+
+Tip: You can invoke this command directly with a handoff path: `/ff_resume_handoff `thoughts/shared/handoffs/ENG-XXXX/YYYY-MM-DD_HH-MM-SS_ENG-XXXX_description.md`
+
+or using a ticket number to resume from the most recent handoff for that ticket: `/ff_resume_handoff ENG-XXXX`
+```
+
+Then wait for the user's input.
+
+## Process Steps
+
+### Step 1: Read and Analyze Handoff
+
+1. **Read handoff document completely**:
+   - Use the Read tool WITHOUT limit/offset parameters
+   - Extract all sections:
+     - Task(s) and their statuses
+     - Recent changes
+     - Learnings
+     - Artifacts
+     - Action items and next steps
+     - Other notes
+
+2. **Spawn focused research tasks**:
+   Based on the handoff content, spawn parallel research tasks to verify current state:
+
+   ```
+   Task 1 - Gather artifact context:
+   Read all artifacts mentioned in the handoff.
+   1. Read feature documents listed in "Artifacts"
+   2. Read implementation plans referenced
+   3. Read any research documents mentioned
+   4. Extract key requirements and decisions
+   Use tools: Read
+   Return: Summary of artifact contents and key decisions
+   ```
+
+3. **Wait for ALL sub-tasks to complete** before proceeding
+
+4. **Read critical files identified**:
+   - Read files from "Learnings" section completely
+   - Read files from "Recent changes" to understand modifications
+   - Read any new related files discovered during research
+
+### Step 2: Synthesize and Present Analysis
+
+1. **Present comprehensive analysis**:
+   ```
+   I've analyzed the handoff from [date] by [researcher]. Here's the current situation:
+
+   **Original Tasks:**
+   - [Task 1]: [Status from handoff] → [Current verification]
+   - [Task 2]: [Status from handoff] → [Current verification]
+
+   **Key Learnings Validated:**
+   - [Learning with file:line reference] - [Still valid/Changed]
+   - [Pattern discovered] - [Still applicable/Modified]
+
+   **Recent Changes Status:**
+   - [Change 1] - [Verified present/Missing/Modified]
+   - [Change 2] - [Verified present/Missing/Modified]
+
+   **Artifacts Reviewed:**
+   - [Document 1]: [Key takeaway]
+   - [Document 2]: [Key takeaway]
+
+   **Recommended Next Actions:**
+   Based on the handoff's action items and current state:
+   1. [Most logical next step based on handoff]
+   2. [Second priority action]
+   3. [Additional tasks discovered]
+
+   **Potential Issues Identified:**
+   - [Any conflicts or regressions found]
+   - [Missing dependencies or broken code]
+
+   Shall I proceed with [recommended action 1], or would you like to adjust the approach?
+   ```
+
+2. **Get confirmation** before proceeding
+
+### Step 3: Create Action Plan
+
+1. **Use TodoWrite to create task list**:
+   - Convert action items from handoff into todos
+   - Add any new tasks discovered during analysis
+   - Prioritize based on dependencies and handoff guidance
+
+2. **Present the plan**:
+   ```
+   I've created a task list based on the handoff and current analysis:
+
+   [Show todo list]
+
+   Ready to begin with the first task: [task description]?
+   ```
+
+### Step 4: Begin Implementation
+
+1. **Start with the first approved task**
+2. **Reference learnings from handoff** throughout implementation
+3. **Apply patterns and approaches documented** in the handoff
+4. **Update progress** as tasks are completed
+
+## Guidelines
+
+1. **Be Thorough in Analysis**:
+   - Read the entire handoff document first
+   - Verify ALL mentioned changes still exist
+   - Check for any regressions or conflicts
+   - Read all referenced artifacts
+
+2. **Be Interactive**:
+   - Present findings before starting work
+   - Get buy-in on the approach
+   - Allow for course corrections
+   - Adapt based on current state vs handoff state
+
+3. **Leverage Handoff Wisdom**:
+   - Pay special attention to "Learnings" section
+   - Apply documented patterns and approaches
+   - Avoid repeating mistakes mentioned
+   - Build on discovered solutions
+
+4. **Track Continuity**:
+   - Use TodoWrite to maintain task continuity
+   - Reference the handoff document in commits
+   - Document any deviations from original plan
+   - Consider creating a new handoff when done
+
+5. **Validate Before Acting**:
+   - Never assume handoff state matches current state
+   - Verify all file references still exist
+   - Check for breaking changes since handoff
+   - Confirm patterns are still valid
+
+## Common Scenarios
+
+### Scenario 1: Clean Continuation
+- All changes from handoff are present
+- No conflicts or regressions
+- Clear next steps in action items
+- Proceed with recommended actions
+
+### Scenario 2: Diverged Codebase
+- Some changes missing or modified
+- New related code added since handoff
+- Need to reconcile differences
+- Adapt plan based on current state
+
+### Scenario 3: Incomplete Handoff Work
+- Tasks marked as "in_progress" in handoff
+- Need to complete unfinished work first
+- May need to re-understand partial implementations
+- Focus on completing before new work
+
+### Scenario 4: Stale Handoff
+- Significant time has passed
+- Major refactoring has occurred
+- Original approach may no longer apply
+- Need to re-evaluate strategy
+
+## Example Interaction Flow
+
+```
+User: /ff_resume_handoff specification/feature/handoffs/handoff-0.md
+Assistant: Let me read and analyze that handoff document...
+
+[Reads handoff completely]
+[Spawns research tasks]
+[Waits for completion]
+[Reads identified files]
+
+I've analyzed the handoff from [date]. Here's the current situation...
+
+[Presents analysis]
+
+Shall I proceed with implementing the webhook validation fix, or would you like to adjust the approach?
+
+User: Yes, proceed with the webhook validation
+Assistant: [Creates todo list and begins implementation]
+```

--- a/.agents/skills/source-command-ff-validate-plan/SKILL.md
+++ b/.agents/skills/source-command-ff-validate-plan/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: "source-command-ff-validate-plan"
+description: "Validate implementation against plan, verify success criteria, identify issues"
+---
+
+# source-command-ff-validate-plan
+
+Use this skill when the user asks to run the migrated source command `ff_validate_plan`.
+
+## Command Template
+
+# Validate Plan
+
+You are tasked with validating that an implementation plan was correctly executed, verifying all success criteria and identifying any deviations or issues.
+
+## Initial Setup
+
+When invoked:
+1. **Determine context** - Are you in an existing conversation or starting fresh?
+   - If existing: Review what was implemented in this session
+   - If fresh: Need to discover what was done through git and codebase analysis
+
+2. **Locate the plan**:
+   - If plan path provided, use it
+   - Otherwise, search recent commits for plan references or ask user
+
+3. **Gather implementation evidence**:
+   ```bash
+   # Check recent commits
+   git log --oneline -n 20
+   git diff HEAD~N..HEAD  # Where N covers implementation commits
+
+   # Run comprehensive checks
+   cd $(git rev-parse --show-toplevel) && make check test
+   ```
+
+## Validation Process
+
+### Step 1: Context Discovery
+
+If starting fresh or need more context:
+
+1. **Read the implementation plan** completely
+2. **Identify what should have changed**:
+   - List all files that should be modified
+   - Note all success criteria (automated and manual)
+   - Identify key functionality to verify
+
+3. **Spawn parallel research tasks** to discover implementation:
+   ```
+   Task 1 - Verify database changes:
+   Research if migration [N] was added and schema changes match plan.
+   Check: migration files, schema version, table structure
+   Return: What was implemented vs what plan specified
+
+   Task 2 - Verify code changes:
+   Find all modified files related to [feature].
+   Compare actual changes to plan specifications.
+   Return: File-by-file comparison of planned vs actual
+
+   Task 3 - Verify test coverage:
+   Check if tests were added/modified as specified.
+   Run test commands and capture results.
+   Return: Test status and any missing coverage
+   ```
+
+### Step 2: Systematic Validation
+
+For each phase in the plan:
+
+1. **Check completion status**:
+   - Look for checkmarks in the plan (- [x])
+   - Verify the actual code matches claimed completion
+
+2. **Run automated verification**:
+   - Execute each command from "Automated Verification"
+   - Document pass/fail status
+   - If failures, investigate root cause
+
+3. **Assess manual criteria**:
+   - List what needs manual testing
+   - Provide clear steps for user verification
+
+4. **Think deeply about edge cases**:
+   - Were error conditions handled?
+   - Are there missing validations?
+   - Could the implementation break existing functionality?
+
+### Step 3: Generate Validation Report
+
+Create comprehensive validation summary:
+
+```markdown
+## Validation Report: [Plan Name]
+
+### Implementation Status
+✓ Phase 1: [Name] - Fully implemented
+✓ Phase 2: [Name] - Fully implemented
+⚠️ Phase 3: [Name] - Partially implemented (see issues)
+
+### Automated Verification Results
+✓ Build passes: `make build`
+✓ Tests pass: `make test`
+✗ Linting issues: `make lint` (3 warnings)
+
+### Code Review Findings
+
+#### Matches Plan:
+- Database migration correctly adds [table]
+- API endpoints implement specified methods
+- Error handling follows plan
+
+#### Deviations from Plan:
+- Used different variable names in [file:line]
+- Added extra validation in [file:line] (improvement)
+
+#### Potential Issues:
+- Missing index on foreign key could impact performance
+- No rollback handling in migration
+
+### Manual Testing Required:
+1. UI functionality:
+   - [ ] Verify [feature] appears correctly
+   - [ ] Test error states with invalid input
+
+2. Integration:
+   - [ ] Confirm works with existing [component]
+   - [ ] Check performance with large datasets
+
+### Recommendations:
+- Address linting warnings before merge
+- Consider adding integration test for [scenario]
+- Document new API endpoints
+```
+
+## Working with Existing Context
+
+If you were part of the implementation:
+- Review the conversation history
+- Check your todo list for what was completed
+- Focus validation on work done in this session
+- Be honest about any shortcuts or incomplete items
+
+## Important Guidelines
+
+1. **Be thorough but practical** - Focus on what matters
+2. **Run all automated checks** - Don't skip verification commands
+3. **Document everything** - Both successes and issues
+4. **Think critically** - Question if the implementation truly solves the problem
+5. **Consider maintenance** - Will this be maintainable long-term?
+
+## Validation Checklist
+
+Always verify:
+- [ ] All phases marked complete are actually done
+- [ ] Automated tests pass
+- [ ] Code follows existing patterns
+- [ ] No regressions introduced
+- [ ] Error handling is robust
+- [ ] Documentation updated if needed
+- [ ] Manual test steps are clear
+
+## Relationship to Other Commands
+
+Recommended workflow:
+1. `/ff_implement_plan` - Execute the implementation
+2. `/ff_commit` - Create atomic commits for changes
+3. `/ff_validate_plan` - Verify implementation correctness
+4. `/ff_describe_pr` - Generate PR description
+
+The validation works best after commits are made, as it can analyze the git history to understand what was implemented.
+
+Remember: Good validation catches issues before they reach production. Be constructive but thorough in identifying gaps or improvements.

--- a/.agents/skills/source-command-implement-plan/SKILL.md
+++ b/.agents/skills/source-command-implement-plan/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: "source-command-implement-plan"
+description: "Implement technical plans from thoughts/shared/plans with verification"
+---
+
+# source-command-implement-plan
+
+Use this skill when the user asks to run the migrated source command `implement_plan`.
+
+## Command Template
+
+# Implement Plan
+
+You are tasked with implementing an approved technical plan from `thoughts/shared/plans/`. These plans contain phases with specific changes and success criteria.
+
+## Getting Started
+
+When given a plan path:
+- Read the plan completely and check for any existing checkmarks (- [x])
+- Read the original ticket and all files mentioned in the plan
+- **Read files fully** - never use limit/offset parameters, you need complete context
+- Think deeply about how the pieces fit together
+- Create a todo list to track your progress
+- Start implementing if you understand what needs to be done
+
+If no plan path provided, ask for one.
+
+## Implementation Philosophy
+
+Plans are carefully designed, but reality can be messy. Your job is to:
+- Follow the plan's intent while adapting to what you find
+- Implement each phase fully before moving to the next
+- Verify your work makes sense in the broader codebase context
+- Update checkboxes in the plan as you complete sections
+
+When things don't match the plan exactly, think about why and communicate clearly. The plan is your guide, but your judgment matters too.
+
+If you encounter a mismatch:
+- STOP and think deeply about why the plan can't be followed
+- Present the issue clearly:
+  ```
+  Issue in Phase [N]:
+  Expected: [what the plan says]
+  Found: [actual situation]
+  Why this matters: [explanation]
+
+  How should I proceed?
+  ```
+
+## Verification Approach
+
+After implementing a phase:
+- Run the success criteria checks (usually `make check test` covers everything)
+- Fix any issues before proceeding
+- Update your progress in both the plan and your todos
+- Check off completed items in the plan file itself using Edit
+- **Pause for human verification**: After completing all automated verification for a phase, pause and inform the human that the phase is ready for manual testing. Use this format:
+  ```
+  Phase [N] Complete - Ready for Manual Verification
+
+  Automated verification passed:
+  - [List automated checks that passed]
+
+  Please perform the manual verification steps listed in the plan:
+  - [List manual verification items from the plan]
+
+  Let me know when manual testing is complete so I can proceed to Phase [N+1].
+  ```
+
+If instructed to execute multiple phases consecutively, skip the pause until the last phase. Otherwise, assume you are just doing one phase.
+
+do not check off items in the manual testing steps until confirmed by the user.
+
+
+## If You Get Stuck
+
+When something isn't working as expected:
+- First, make sure you've read and understood all the relevant code
+- Consider if the codebase has evolved since the plan was written
+- Present the mismatch clearly and ask for guidance
+
+Use sub-tasks sparingly - mainly for targeted debugging or exploring unfamiliar territory.
+
+## Resuming Work
+
+If the plan has existing checkmarks:
+- Trust that completed work is done
+- Pick up from the first unchecked item
+- Verify previous work only if something seems off
+
+Remember: You're implementing a solution, not just checking boxes. Keep the end goal in mind and maintain forward momentum.

--- a/.agents/skills/source-command-iterate-plan/SKILL.md
+++ b/.agents/skills/source-command-iterate-plan/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: "source-command-iterate-plan"
+description: "Iterate on existing implementation plans with thorough research and updates"
+---
+
+# source-command-iterate-plan
+
+Use this skill when the user asks to run the migrated source command `iterate_plan`.
+
+## Command Template
+
+# Iterate Implementation Plan
+
+You are tasked with updating existing implementation plans based on user feedback. You should be skeptical, thorough, and ensure changes are grounded in actual codebase reality.
+
+## Initial Response
+
+When this command is invoked:
+
+1. **Parse the input to identify**:
+   - Plan file path (e.g., `thoughts/shared/plans/2025-10-16-feature.md`)
+   - Requested changes/feedback
+
+2. **Handle different input scenarios**:
+
+   **If NO plan file provided**:
+   ```
+   I'll help you iterate on an existing implementation plan.
+
+   Which plan would you like to update? Please provide the path to the plan file (e.g., `thoughts/shared/plans/2025-10-16-feature.md`).
+
+   Tip: You can list recent plans with `ls -lt thoughts/shared/plans/ | head`
+   ```
+   Wait for user input, then re-check for feedback.
+
+   **If plan file provided but NO feedback**:
+   ```
+   I've found the plan at [path]. What changes would you like to make?
+
+   For example:
+   - "Add a phase for migration handling"
+   - "Update the success criteria to include performance tests"
+   - "Adjust the scope to exclude feature X"
+   - "Split Phase 2 into two separate phases"
+   ```
+   Wait for user input.
+
+   **If BOTH plan file AND feedback provided**:
+   - Proceed immediately to Step 1
+   - No preliminary questions needed
+
+## Process Steps
+
+### Step 1: Read and Understand Current Plan
+
+1. **Read the existing plan file COMPLETELY**:
+   - Use the Read tool WITHOUT limit/offset parameters
+   - Understand the current structure, phases, and scope
+   - Note the success criteria and implementation approach
+
+2. **Understand the requested changes**:
+   - Parse what the user wants to add/modify/remove
+   - Identify if changes require codebase research
+   - Determine scope of the update
+
+### Step 2: Research If Needed
+
+**Only spawn research tasks if the changes require new technical understanding.**
+
+If the user's feedback requires understanding new code patterns or validating assumptions:
+
+1. **Create a research todo list** using TodoWrite
+
+2. **Spawn parallel sub-tasks for research**:
+   Use the right agent for each type of research:
+
+   **For code investigation:**
+   - **codebase-locator** - To find relevant files
+   - **codebase-analyzer** - To understand implementation details
+   - **codebase-pattern-finder** - To find similar patterns
+
+   **For historical context:**
+   - **thoughts-locator** - To find related research or decisions
+   - **thoughts-analyzer** - To extract insights from documents
+
+   **Be EXTREMELY specific about directories**:
+   - If the change involves "WUI", specify `humanlayer-wui/` directory
+   - If it involves "daemon", specify `hld/` directory
+   - Include full path context in prompts
+
+3. **Read any new files identified by research**:
+   - Read them FULLY into the main context
+   - Cross-reference with the plan requirements
+
+4. **Wait for ALL sub-tasks to complete** before proceeding
+
+### Step 3: Present Understanding and Approach
+
+Before making changes, confirm your understanding:
+
+```
+Based on your feedback, I understand you want to:
+- [Change 1 with specific detail]
+- [Change 2 with specific detail]
+
+My research found:
+- [Relevant code pattern or constraint]
+- [Important discovery that affects the change]
+
+I plan to update the plan by:
+1. [Specific modification to make]
+2. [Another modification]
+
+Does this align with your intent?
+```
+
+Get user confirmation before proceeding.
+
+### Step 4: Update the Plan
+
+1. **Make focused, precise edits** to the existing plan:
+   - Use the Edit tool for surgical changes
+   - Maintain the existing structure unless explicitly changing it
+   - Keep all file:line references accurate
+   - Update success criteria if needed
+
+2. **Ensure consistency**:
+   - If adding a new phase, ensure it follows the existing pattern
+   - If modifying scope, update "What We're NOT Doing" section
+   - If changing approach, update "Implementation Approach" section
+   - Maintain the distinction between automated vs manual success criteria
+
+3. **Preserve quality standards**:
+   - Include specific file paths and line numbers for new content
+   - Write measurable success criteria
+   - Use `make` commands for automated verification
+   - Keep language clear and actionable
+
+### Step 5: Sync and Review
+
+1. **Sync the updated plan**:
+   - Run `humanlayer thoughts sync`
+   - This ensures changes are properly indexed
+
+2. **Present the changes made**:
+   ```
+   I've updated the plan at `thoughts/shared/plans/[filename].md`
+
+   Changes made:
+   - [Specific change 1]
+   - [Specific change 2]
+
+   The updated plan now:
+   - [Key improvement]
+   - [Another improvement]
+
+   Would you like any further adjustments?
+   ```
+
+3. **Be ready to iterate further** based on feedback
+
+## Important Guidelines
+
+1. **Be Skeptical**:
+   - Don't blindly accept change requests that seem problematic
+   - Question vague feedback - ask for clarification
+   - Verify technical feasibility with code research
+   - Point out potential conflicts with existing plan phases
+
+2. **Be Surgical**:
+   - Make precise edits, not wholesale rewrites
+   - Preserve good content that doesn't need changing
+   - Only research what's necessary for the specific changes
+   - Don't over-engineer the updates
+
+3. **Be Thorough**:
+   - Read the entire existing plan before making changes
+   - Research code patterns if changes require new technical understanding
+   - Ensure updated sections maintain quality standards
+   - Verify success criteria are still measurable
+
+4. **Be Interactive**:
+   - Confirm understanding before making changes
+   - Show what you plan to change before doing it
+   - Allow course corrections
+   - Don't disappear into research without communicating
+
+5. **Track Progress**:
+   - Use TodoWrite to track update tasks if complex
+   - Update todos as you complete research
+   - Mark tasks complete when done
+
+6. **No Open Questions**:
+   - If the requested change raises questions, ASK
+   - Research or get clarification immediately
+   - Do NOT update the plan with unresolved questions
+   - Every change must be complete and actionable
+
+## Success Criteria Guidelines
+
+When updating success criteria, always maintain the two-category structure:
+
+1. **Automated Verification** (can be run by execution agents):
+   - Commands that can be run: `make test`, `npm run lint`, etc.
+   - Prefer `make` commands: `make -C humanlayer-wui check` instead of `cd humanlayer-wui && bun run fmt`
+   - Specific files that should exist
+   - Code compilation/type checking
+
+2. **Manual Verification** (requires human testing):
+   - UI/UX functionality
+   - Performance under real conditions
+   - Edge cases that are hard to automate
+   - User acceptance criteria
+
+## Sub-task Spawning Best Practices
+
+When spawning research sub-tasks:
+
+1. **Only spawn if truly needed** - don't research for simple changes
+2. **Spawn multiple tasks in parallel** for efficiency
+3. **Each task should be focused** on a specific area
+4. **Provide detailed instructions** including:
+   - Exactly what to search for
+   - Which directories to focus on
+   - What information to extract
+   - Expected output format
+5. **Request specific file:line references** in responses
+6. **Wait for all tasks to complete** before synthesizing
+7. **Verify sub-task results** - if something seems off, spawn follow-up tasks
+
+## Example Interaction Flows
+
+**Scenario 1: User provides everything upfront**
+```
+User: /iterate_plan thoughts/shared/plans/2025-10-16-feature.md - add phase for error handling
+Assistant: [Reads plan, researches error handling patterns, updates plan]
+```
+
+**Scenario 2: User provides just plan file**
+```
+User: /iterate_plan thoughts/shared/plans/2025-10-16-feature.md
+Assistant: I've found the plan. What changes would you like to make?
+User: Split Phase 2 into two phases - one for backend, one for frontend
+Assistant: [Proceeds with update]
+```
+
+**Scenario 3: User provides no arguments**
+```
+User: /iterate_plan
+Assistant: Which plan would you like to update? Please provide the path...
+User: thoughts/shared/plans/2025-10-16-feature.md
+Assistant: I've found the plan. What changes would you like to make?
+User: Add more specific success criteria
+Assistant: [Proceeds with update]
+```

--- a/.agents/skills/source-command-linear/SKILL.md
+++ b/.agents/skills/source-command-linear/SKILL.md
@@ -1,0 +1,395 @@
+---
+name: "source-command-linear"
+description: "Manage Linear tickets - create, update, comment, and follow workflow patterns"
+---
+
+# source-command-linear
+
+Use this skill when the user asks to run the migrated source command `linear`.
+
+## Command Template
+
+# Linear - Ticket Management
+
+You are tasked with managing Linear tickets, including creating tickets from thoughts documents, updating existing tickets, and following the team's specific workflow patterns.
+
+## Initial Setup
+
+First, verify that Linear MCP tools are available by checking if any `mcp__linear__` tools exist. If not, respond:
+```
+I need access to Linear tools to help with ticket management. Please run the `/mcp` command to enable the Linear MCP server, then try again.
+```
+
+If tools are available, respond based on the user's request:
+
+### For general requests:
+```
+I can help you with Linear tickets. What would you like to do?
+1. Create a new ticket from a thoughts document
+2. Add a comment to a ticket (I'll use our conversation context)
+3. Search for tickets
+4. Update ticket status or details
+```
+
+### For specific create requests:
+```
+I'll help you create a Linear ticket from your thoughts document. Please provide:
+1. The path to the thoughts document (or topic to search for)
+2. Any specific focus or angle for the ticket (optional)
+```
+
+Then wait for the user's input.
+
+## Team Workflow & Status Progression
+
+The team follows a specific workflow to ensure alignment before code implementation:
+
+1. **Triage** → All new tickets start here for initial review
+2. **Spec Needed** → More detail is needed - problem to solve and solution outline necessary
+3. **Research Needed** → Ticket requires investigation before plan can be written
+4. **Research in Progress** → Active research/investigation underway
+5. **Research in Review** → Research findings under review (optional step)
+6. **Ready for Plan** → Research complete, ticket needs an implementation plan
+7. **Plan in Progress** → Actively writing the implementation plan
+8. **Plan in Review** → Plan is written and under discussion
+9. **Ready for Dev** → Plan approved, ready for implementation
+10. **In Dev** → Active development
+11. **Code Review** → PR submitted
+12. **Done** → Completed
+
+**Key principle**: Review and alignment happen at the plan stage (not PR stage) to move faster and avoid rework.
+
+## Important Conventions
+
+### URL Mapping for Thoughts Documents
+When referencing thoughts documents, always provide GitHub links using the `links` parameter:
+- `thoughts/shared/...` → `https://github.com/humanlayer/thoughts/blob/main/repos/humanlayer/shared/...`
+- `thoughts/allison/...` → `https://github.com/humanlayer/thoughts/blob/main/repos/humanlayer/allison/...`
+- `thoughts/global/...` → `https://github.com/humanlayer/thoughts/blob/main/global/...`
+
+### Default Values
+- **Status**: Always create new tickets in "Triage" status
+- **Project**: For new tickets, default to "M U L T I C L A U D E" (ID: f11c8d63-9120-4393-bfae-553da0b04fd8) unless told otherwise
+- **Priority**: Default to Medium (3) for most tasks, use best judgment or ask user
+  - Urgent (1): Critical blockers, security issues
+  - High (2): Important features with deadlines, major bugs
+  - Medium (3): Standard implementation tasks (default)
+  - Low (4): Nice-to-haves, minor improvements
+- **Links**: Use the `links` parameter to attach URLs (not just markdown links in description)
+
+### Automatic Label Assignment
+Automatically apply labels based on the ticket content:
+- **hld**: For tickets about the `hld/` directory (the daemon)
+- **wui**: For tickets about `humanlayer-wui/`
+- **meta**: For tickets about `hlyr` commands, thoughts tool, or `thoughts/` directory
+
+Note: meta is mutually exclusive with hld/wui. Tickets can have both hld and wui, but not meta with either.
+
+## Action-Specific Instructions
+
+### 1. Creating Tickets from Thoughts
+
+#### Steps to follow after receiving the request:
+
+1. **Locate and read the thoughts document:**
+   - If given a path, read the document directly
+   - If given a topic/keyword, search thoughts/ directory using Grep to find relevant documents
+   - If multiple matches found, show list and ask user to select
+   - Create a TodoWrite list to track: Read document → Analyze content → Draft ticket → Get user input → Create ticket
+
+2. **Analyze the document content:**
+   - Identify the core problem or feature being discussed
+   - Extract key implementation details or technical decisions
+   - Note any specific code files or areas mentioned
+   - Look for action items or next steps
+   - Identify what stage the idea is at (early ideation vs ready to implement)
+   - Take time to ultrathink about distilling the essence of this document into a clear problem statement and solution approach
+
+3. **Check for related context (if mentioned in doc):**
+   - If the document references specific code files, read relevant sections
+   - If it mentions other thoughts documents, quickly check them
+   - Look for any existing Linear tickets mentioned
+
+4. **Get Linear workspace context:**
+   - List teams: `mcp__linear__list_teams`
+   - If multiple teams, ask user to select one
+   - List projects for selected team: `mcp__linear__list_projects`
+
+5. **Draft the ticket summary:**
+   Present a draft to the user:
+   ```
+   ## Draft Linear Ticket
+
+   **Title**: [Clear, action-oriented title]
+
+   **Description**:
+   [2-3 sentence summary of the problem/goal]
+
+   ## Key Details
+   - [Bullet points of important details from thoughts]
+   - [Technical decisions or constraints]
+   - [Any specific requirements]
+
+   ## Implementation Notes (if applicable)
+   [Any specific technical approach or steps outlined]
+
+   ## References
+   - Source: `thoughts/[path/to/document.md]` ([View on GitHub](converted GitHub URL))
+   - Related code: [any file:line references]
+   - Parent ticket: [if applicable]
+
+   ---
+   Based on the document, this seems to be at the stage of: [ideation/planning/ready to implement]
+   ```
+
+6. **Interactive refinement:**
+   Ask the user:
+   - Does this summary capture the ticket accurately?
+   - Which project should this go in? [show list]
+   - What priority? (Default: Medium/3)
+   - Any additional context to add?
+   - Should we include more/less implementation detail?
+   - Do you want to assign it to yourself?
+
+   Note: Ticket will be created in "Triage" status by default.
+
+7. **Create the Linear ticket:**
+   ```
+   mcp__linear__create_issue with:
+   - title: [refined title]
+   - description: [final description in markdown]
+   - teamId: [selected team]
+   - projectId: [use default project from above unless user specifies]
+   - priority: [selected priority number, default 3]
+   - stateId: [Triage status ID]
+   - assigneeId: [if requested]
+   - labelIds: [apply automatic label assignment from above]
+   - links: [{url: "GitHub URL", title: "Document Title"}]
+   ```
+
+8. **Post-creation actions:**
+   - Show the created ticket URL
+   - Ask if user wants to:
+     - Add a comment with additional implementation details
+     - Create sub-tasks for specific action items
+     - Update the original thoughts document with the ticket reference
+   - If yes to updating thoughts doc:
+     ```
+     Add at the top of the document:
+     ---
+     linear_ticket: [URL]
+     created: [date]
+     ---
+     ```
+
+## Example transformations:
+
+### From verbose thoughts:
+```
+"I've been thinking about how our resumed sessions don't inherit permissions properly.
+This is causing issues where users have to re-specify everything. We should probably
+store all the config in the database and then pull it when resuming. Maybe we need
+new columns for permission_prompt_tool and allowed_tools..."
+```
+
+### To concise ticket:
+```
+Title: Fix resumed sessions to inherit all configuration from parent
+
+Description:
+
+## Problem to solve
+Currently, resumed sessions only inherit Model and WorkingDir from parent sessions,
+causing all other configuration to be lost. Users must re-specify permissions and
+settings when resuming.
+
+## Solution
+Store all session configuration in the database and automatically inherit it when
+resuming sessions, with support for explicit overrides.
+```
+
+### 2. Adding Comments and Links to Existing Tickets
+
+When user wants to add a comment to a ticket:
+
+1. **Determine which ticket:**
+   - Use context from the current conversation to identify the relevant ticket
+   - If uncertain, use `mcp__linear__get_issue` to show ticket details and confirm with user
+   - Look for ticket references in recent work discussed
+
+2. **Format comments for clarity:**
+   - Attempt to keep comments concise (~10 lines) unless more detail is needed
+   - Focus on the key insight or most useful information for a human reader
+   - Not just what was done, but what matters about it
+   - Include relevant file references with backticks and GitHub links
+
+3. **File reference formatting:**
+   - Wrap paths in backticks: `thoughts/allison/example.md`
+   - Add GitHub link after: `([View](url))`
+   - Do this for both thoughts/ and code files mentioned
+
+4. **Comment structure example:**
+   ```markdown
+   Implemented retry logic in webhook handler to address rate limit issues.
+
+   Key insight: The 429 responses were clustered during batch operations,
+   so exponential backoff alone wasn't sufficient - added request queuing.
+
+   Files updated:
+   - `hld/webhooks/handler.go` ([GitHub](link))
+   - `thoughts/shared/rate_limit_analysis.md` ([GitHub](link))
+   ```
+
+5. **Handle links properly:**
+   - If adding a link with a comment: Update the issue with the link AND mention it in the comment
+   - If only adding a link: Still create a comment noting what link was added for posterity
+   - Always add links to the issue itself using the `links` parameter
+
+6. **For comments with links:**
+   ```
+   # First, update the issue with the link
+   mcp__linear__update_issue with:
+   - id: [ticket ID]
+   - links: [existing links + new link with proper title]
+
+   # Then, create the comment mentioning the link
+   mcp__linear__create_comment with:
+   - issueId: [ticket ID]
+   - body: [formatted comment with key insights and file references]
+   ```
+
+7. **For links only:**
+   ```
+   # Update the issue with the link
+   mcp__linear__update_issue with:
+   - id: [ticket ID]
+   - links: [existing links + new link with proper title]
+
+   # Add a brief comment for posterity
+   mcp__linear__create_comment with:
+   - issueId: [ticket ID]
+   - body: "Added link: `path/to/document.md` ([View](url))"
+   ```
+
+### 3. Searching for Tickets
+
+When user wants to find tickets:
+
+1. **Gather search criteria:**
+   - Query text
+   - Team/Project filters
+   - Status filters
+   - Date ranges (createdAt, updatedAt)
+
+2. **Execute search:**
+   ```
+   mcp__linear__list_issues with:
+   - query: [search text]
+   - teamId: [if specified]
+   - projectId: [if specified]
+   - stateId: [if filtering by status]
+   - limit: 20
+   ```
+
+3. **Present results:**
+   - Show ticket ID, title, status, assignee
+   - Group by project if multiple projects
+   - Include direct links to Linear
+
+### 4. Updating Ticket Status
+
+When moving tickets through the workflow:
+
+1. **Get current status:**
+   - Fetch ticket details
+   - Show current status in workflow
+
+2. **Suggest next status:**
+   - Triage → Spec Needed (lacks detail/problem statement)
+   - Spec Needed → Research Needed (once problem/solution outlined)
+   - Research Needed → Research in Progress (starting research)
+   - Research in Progress → Research in Review (optional, can skip to Ready for Plan)
+   - Research in Review → Ready for Plan (research approved)
+   - Ready for Plan → Plan in Progress (starting to write plan)
+   - Plan in Progress → Plan in Review (plan written)
+   - Plan in Review → Ready for Dev (plan approved)
+   - Ready for Dev → In Dev (work started)
+
+3. **Update with context:**
+   ```
+   mcp__linear__update_issue with:
+   - id: [ticket ID]
+   - stateId: [new status ID]
+   ```
+
+   Consider adding a comment explaining the status change.
+
+## Important Notes
+
+- Tag users in descriptions and comments using `@[name](ID)` format, e.g., `@[dex](16765c85-2286-4c0f-ab49-0d4d79222ef5)`
+- Keep tickets concise but complete - aim for scannable content
+- All tickets should include a clear "problem to solve" - if the user asks for a ticket and only gives implementation details, you MUST ask "To write a good ticket, please explain the problem you're trying to solve from a user perspective"
+- Focus on the "what" and "why", include "how" only if well-defined
+- Always preserve links to source material using the `links` parameter
+- Don't create tickets from early-stage brainstorming unless requested
+- Use proper Linear markdown formatting
+- Include code references as: `path/to/file.ext:linenum`
+- Ask for clarification rather than guessing project/status
+- Remember that Linear descriptions support full markdown including code blocks
+- Always use the `links` parameter for external URLs (not just markdown links)
+- remember - you must get a "Problem to solve"!
+
+## Comment Quality Guidelines
+
+When creating comments, focus on extracting the **most valuable information** for a human reader:
+
+- **Key insights over summaries**: What's the "aha" moment or critical understanding?
+- **Decisions and tradeoffs**: What approach was chosen and what it enables/prevents
+- **Blockers resolved**: What was preventing progress and how it was addressed
+- **State changes**: What's different now and what it means for next steps
+- **Surprises or discoveries**: Unexpected findings that affect the work
+
+Avoid:
+- Mechanical lists of changes without context
+- Restating what's obvious from code diffs
+- Generic summaries that don't add value
+
+Remember: The goal is to help a future reader (including yourself) quickly understand what matters about this update.
+
+## Commonly Used IDs
+
+### Engineering Team
+- **Team ID**: `6b3b2115-efd4-4b83-8463-8160842d2c84`
+
+### Label IDs
+- **bug**: `ff23dde3-199b-421e-904c-4b9f9b3d452c`
+- **hld**: `d28453c8-e53e-4a06-bea9-b5bbfad5f88a`
+- **meta**: `7a5abaae-f343-4f52-98b0-7987048b0cfa`
+- **wui**: `996deb94-ba0f-4375-8b01-913e81477c4b`
+
+### Workflow State IDs
+- **Triage**: `77da144d-fe13-4c3a-a53a-cfebd06c0cbe` (type: triage)
+- **spec needed**: `274beb99-bff8-4d7b-85cf-04d18affbc82` (type: unstarted)
+- **research needed**: `d0b89672-8189-45d6-b705-50afd6c94a91` (type: unstarted)
+- **research in progress**: `c41c5a23-ce25-471f-b70a-eff1dca60ffd` (type: unstarted)
+- **research in review**: `1a9363a7-3fae-42ee-a6c8-1fc714656f09` (type: unstarted)
+- **ready for plan**: `995011dd-3e36-46e5-b776-5a4628d06cc8` (type: unstarted)
+- **plan in progress**: `a52b4793-d1b6-4e5d-be79-b2254185eed0` (type: started)
+- **plan in review**: `15f56065-41ea-4d9a-ab8c-ec8e1a811a7a` (type: started)
+- **ready for dev**: `c25bae2f-856a-4718-aaa8-b469b7822f58` (type: started)
+- **in dev**: `6be18699-18d7-496e-a7c9-37d2ddefe612` (type: started)
+- **code review**: `8ca7fda1-08d4-48fb-a0cf-954246ccbe66` (type: started)
+- **Ready for Deploy**: `a3ad0b54-17bf-4ad3-b1c1-2f56c1f2515a` (type: started)
+- **Done**: `8159f431-fbc7-495f-a861-1ba12040f672` (type: completed)
+- **Backlog**: `6cf6b25a-054a-469b-9845-9bd9ab39ad76` (type: backlog)
+- **PostIts**: `a57f2ab3-c6f8-44c7-a36b-896154729338` (type: backlog)
+- **Todo**: `ddf85246-3a7c-4141-a377-09069812bbc3` (type: unstarted)
+- **Duplicate**: `2bc0e829-9853-4f76-ad34-e8732f062da2` (type: canceled)
+- **Canceled**: `14a28d0d-c6aa-4d8e-9ff2-9801d4cc7de1` (type: canceled)
+
+
+## Linear User IDs
+
+- allison: b157f9e4-8faf-4e7e-a598-dae6dec8a584
+- dex: 16765c85-2286-4c0f-ab49-0d4d79222ef5
+- sundeep: 0062104d-9351-44f5-b64c-d0b59acb516b

--- a/.agents/skills/source-command-local-review/SKILL.md
+++ b/.agents/skills/source-command-local-review/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: "source-command-local-review"
+description: "Set up worktree for reviewing colleague's branch"
+---
+
+# source-command-local-review
+
+Use this skill when the user asks to run the migrated source command `local_review`.
+
+## Command Template
+
+# Local Review
+
+You are tasked with setting up a local review environment for a colleague's branch. This involves creating a worktree, setting up dependencies, and launching a new Codex session.
+
+## Process
+
+When invoked with a parameter like `gh_username:branchName`:
+
+1. **Parse the input**:
+   - Extract GitHub username and branch name from the format `username:branchname`
+   - If no parameter provided, ask for it in the format: `gh_username:branchName`
+
+2. **Extract ticket information**:
+   - Look for ticket numbers in the branch name (e.g., `eng-1696`, `ENG-1696`)
+   - Use this to create a short worktree directory name
+   - If no ticket found, use a sanitized version of the branch name
+
+3. **Set up the remote and worktree**:
+   - Check if the remote already exists using `git remote -v`
+   - If not, add it: `git remote add USERNAME git@github.com:USERNAME/humanlayer`
+   - Fetch from the remote: `git fetch USERNAME`
+   - Create worktree: `git worktree add -b BRANCHNAME ~/wt/humanlayer/SHORT_NAME USERNAME/BRANCHNAME`
+
+4. **Configure the worktree**:
+   - Copy Codex settings: `cp .Codex/settings.local.json WORKTREE/.Codex/`
+   - Run setup: `make -C WORKTREE setup`
+   - Initialize thoughts: `cd WORKTREE && humanlayer thoughts init --directory humanlayer`
+
+## Error Handling
+
+- If worktree already exists, inform the user they need to remove it first
+- If remote fetch fails, check if the username/repo exists
+- If setup fails, provide the error but continue with the launch
+
+## Example Usage
+
+```
+/local_review samdickson22:sam/eng-1696-hotkey-for-yolo-mode
+```
+
+This will:
+- Add 'samdickson22' as a remote
+- Create worktree at `~/wt/humanlayer/eng-1696`
+- Set up the environment

--- a/.agents/skills/source-command-oneshot-plan/SKILL.md
+++ b/.agents/skills/source-command-oneshot-plan/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: "source-command-oneshot-plan"
+description: "Execute ralph plan and implementation for a ticket"
+---
+
+# source-command-oneshot-plan
+
+Use this skill when the user asks to run the migrated source command `oneshot_plan`.
+
+## Command Template
+
+1. use SlashCommand() to call /ralph_plan with the given ticket number
+2. use SlashCommand() to call /ralph_impl with the given ticket number

--- a/.agents/skills/source-command-oneshot/SKILL.md
+++ b/.agents/skills/source-command-oneshot/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: "source-command-oneshot"
+description: "Research ticket and launch planning session"
+---
+
+# source-command-oneshot
+
+Use this skill when the user asks to run the migrated source command `oneshot`.
+
+## Command Template
+
+1. use SlashCommand() to call /ralph_research with the given ticket number
+2. launch a new session with `npx humanlayer launch --model opus --dangerously-skip-permissions --dangerously-skip-permissions-timeout 14m --title "plan ENG-XXXX" "/oneshot_plan ENG-XXXX"`

--- a/.agents/skills/source-command-research-codebase/SKILL.md
+++ b/.agents/skills/source-command-research-codebase/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: "source-command-research-codebase"
+description: "Document codebase as-is with thoughts directory for historical context"
+---
+
+# source-command-research-codebase
+
+Use this skill when the user asks to run the migrated source command `research_codebase`.
+
+## Command Template
+
+# Research Codebase
+
+You are tasked with conducting comprehensive research across the codebase to answer user questions by spawning parallel sub-agents and synthesizing their findings.
+
+## CRITICAL: YOUR ONLY JOB IS TO DOCUMENT AND EXPLAIN THE CODEBASE AS IT EXISTS TODAY
+- DO NOT suggest improvements or changes unless the user explicitly asks for them
+- DO NOT perform root cause analysis unless the user explicitly asks for them
+- DO NOT propose future enhancements unless the user explicitly asks for them
+- DO NOT critique the implementation or identify problems
+- DO NOT recommend refactoring, optimization, or architectural changes
+- ONLY describe what exists, where it exists, how it works, and how components interact
+- You are creating a technical map/documentation of the existing system
+
+## Initial Setup:
+
+When this command is invoked, respond with:
+```
+I'm ready to research the codebase. Please provide your research question or area of interest, and I'll analyze it thoroughly by exploring relevant components and connections.
+```
+
+Then wait for the user's research query.
+
+## Steps to follow after receiving the research query:
+
+1. **Read any directly mentioned files first:**
+   - If the user mentions specific files (tickets, docs, JSON), read them FULLY first
+   - **IMPORTANT**: Use the Read tool WITHOUT limit/offset parameters to read entire files
+   - **CRITICAL**: Read these files yourself in the main context before spawning any sub-tasks
+   - This ensures you have full context before decomposing the research
+
+2. **Analyze and decompose the research question:**
+   - Break down the user's query into composable research areas
+   - Take time to ultrathink about the underlying patterns, connections, and architectural implications the user might be seeking
+   - Identify specific components, patterns, or concepts to investigate
+   - Create a research plan using TodoWrite to track all subtasks
+   - Consider which directories, files, or architectural patterns are relevant
+
+3. **Spawn parallel sub-agent tasks for comprehensive research:**
+   - Create multiple Task agents to research different aspects concurrently
+   - We now have specialized agents that know how to do specific research tasks:
+
+   **For codebase research:**
+   - Use the **codebase-locator** agent to find WHERE files and components live
+   - Use the **codebase-analyzer** agent to understand HOW specific code works (without critiquing it)
+   - Use the **codebase-pattern-finder** agent to find examples of existing patterns (without evaluating them)
+
+   **IMPORTANT**: All agents are documentarians, not critics. They will describe what exists without suggesting improvements or identifying issues.
+
+   **For thoughts directory:**
+   - Use the **thoughts-locator** agent to discover what documents exist about the topic
+   - Use the **thoughts-analyzer** agent to extract key insights from specific documents (only the most relevant ones)
+
+   **For web research (only if user explicitly asks):**
+   - Use the **web-search-researcher** agent for external documentation and resources
+   - IF you use web-research agents, instruct them to return LINKS with their findings, and please INCLUDE those links in your final report
+
+   **For Linear tickets (if relevant):**
+   - Use the **linear-ticket-reader** agent to get full details of a specific ticket
+   - Use the **linear-searcher** agent to find related tickets or historical context
+
+   The key is to use these agents intelligently:
+   - Start with locator agents to find what exists
+   - Then use analyzer agents on the most promising findings to document how they work
+   - Run multiple agents in parallel when they're searching for different things
+   - Each agent knows its job - just tell it what you're looking for
+   - Don't write detailed prompts about HOW to search - the agents already know
+   - Remind agents they are documenting, not evaluating or improving
+
+4. **Wait for all sub-agents to complete and synthesize findings:**
+   - IMPORTANT: Wait for ALL sub-agent tasks to complete before proceeding
+   - Compile all sub-agent results (both codebase and thoughts findings)
+   - Prioritize live codebase findings as primary source of truth
+   - Use thoughts/ findings as supplementary historical context
+   - Connect findings across different components
+   - Include specific file paths and line numbers for reference
+   - Verify all thoughts/ paths are correct (e.g., thoughts/allison/ not thoughts/shared/ for personal files)
+   - Highlight patterns, connections, and architectural decisions
+   - Answer the user's specific questions with concrete evidence
+
+5. **Gather metadata for the research document:**
+   - Run the `hack/spec_metadata.sh` script to generate all relevant metadata
+   - Filename: `thoughts/shared/research/YYYY-MM-DD-ENG-XXXX-description.md`
+     - Format: `YYYY-MM-DD-ENG-XXXX-description.md` where:
+       - YYYY-MM-DD is today's date
+       - ENG-XXXX is the ticket number (omit if no ticket)
+       - description is a brief kebab-case description of the research topic
+     - Examples:
+       - With ticket: `2025-01-08-ENG-1478-parent-child-tracking.md`
+       - Without ticket: `2025-01-08-authentication-flow.md`
+
+6. **Generate research document:**
+   - Use the metadata gathered in step 4
+   - Structure the document with YAML frontmatter followed by content:
+     ```markdown
+     ---
+     date: [Current date and time with timezone in ISO format]
+     researcher: [Researcher name from thoughts status]
+     git_commit: [Current commit hash]
+     branch: [Current branch name]
+     repository: [Repository name]
+     topic: "[User's Question/Topic]"
+     tags: [research, codebase, relevant-component-names]
+     status: complete
+     last_updated: [Current date in YYYY-MM-DD format]
+     last_updated_by: [Researcher name]
+     ---
+
+     # Research: [User's Question/Topic]
+
+     **Date**: [Current date and time with timezone from step 4]
+     **Researcher**: [Researcher name from thoughts status]
+     **Git Commit**: [Current commit hash from step 4]
+     **Branch**: [Current branch name from step 4]
+     **Repository**: [Repository name]
+
+     ## Research Question
+     [Original user query]
+
+     ## Summary
+     [High-level documentation of what was found, answering the user's question by describing what exists]
+
+     ## Detailed Findings
+
+     ### [Component/Area 1]
+     - Description of what exists ([file.ext:line](link))
+     - How it connects to other components
+     - Current implementation details (without evaluation)
+
+     ### [Component/Area 2]
+     ...
+
+     ## Code References
+     - `path/to/file.py:123` - Description of what's there
+     - `another/file.ts:45-67` - Description of the code block
+
+     ## Architecture Documentation
+     [Current patterns, conventions, and design implementations found in the codebase]
+
+     ## Historical Context (from thoughts/)
+     [Relevant insights from thoughts/ directory with references]
+     - `thoughts/shared/something.md` - Historical decision about X
+     - `thoughts/local/notes.md` - Past exploration of Y
+     Note: Paths exclude "searchable/" even if found there
+
+     ## Related Research
+     [Links to other research documents in thoughts/shared/research/]
+
+     ## Open Questions
+     [Any areas that need further investigation]
+     ```
+
+7. **Add GitHub permalinks (if applicable):**
+   - Check if on main branch or if commit is pushed: `git branch --show-current` and `git status`
+   - If on main/master or pushed, generate GitHub permalinks:
+     - Get repo info: `gh repo view --json owner,name`
+     - Create permalinks: `https://github.com/{owner}/{repo}/blob/{commit}/{file}#L{line}`
+   - Replace local file references with permalinks in the document
+
+8. **Sync and present findings:**
+   - Run `humanlayer thoughts sync` to sync the thoughts directory
+   - Present a concise summary of findings to the user
+   - Include key file references for easy navigation
+   - Ask if they have follow-up questions or need clarification
+
+9. **Handle follow-up questions:**
+   - If the user has follow-up questions, append to the same research document
+   - Update the frontmatter fields `last_updated` and `last_updated_by` to reflect the update
+   - Add `last_updated_note: "Added follow-up research for [brief description]"` to frontmatter
+   - Add a new section: `## Follow-up Research [timestamp]`
+   - Spawn new sub-agents as needed for additional investigation
+   - Continue updating the document and syncing
+
+## Important notes:
+- Always use parallel Task agents to maximize efficiency and minimize context usage
+- Always run fresh codebase research - never rely solely on existing research documents
+- The thoughts/ directory provides historical context to supplement live findings
+- Focus on finding concrete file paths and line numbers for developer reference
+- Research documents should be self-contained with all necessary context
+- Each sub-agent prompt should be specific and focused on read-only documentation operations
+- Document cross-component connections and how systems interact
+- Include temporal context (when the research was conducted)
+- Link to GitHub when possible for permanent references
+- Keep the main agent focused on synthesis, not deep file reading
+- Have sub-agents document examples and usage patterns as they exist
+- Explore all of thoughts/ directory, not just research subdirectory
+- **CRITICAL**: You and all sub-agents are documentarians, not evaluators
+- **REMEMBER**: Document what IS, not what SHOULD BE
+- **NO RECOMMENDATIONS**: Only describe the current state of the codebase
+- **File reading**: Always read mentioned files FULLY (no limit/offset) before spawning sub-tasks
+- **Critical ordering**: Follow the numbered steps exactly
+  - ALWAYS read mentioned files first before spawning sub-tasks (step 1)
+  - ALWAYS wait for all sub-agents to complete before synthesizing (step 4)
+  - ALWAYS gather metadata before writing the document (step 5 before step 6)
+  - NEVER write the research document with placeholder values
+- **Path handling**: The thoughts/searchable/ directory contains hard links for searching
+  - Always document paths by removing ONLY "searchable/" - preserve all other subdirectories
+  - Examples of correct transformations:
+    - `thoughts/searchable/allison/old_stuff/notes.md` → `thoughts/allison/old_stuff/notes.md`
+    - `thoughts/searchable/shared/prs/123.md` → `thoughts/shared/prs/123.md`
+    - `thoughts/searchable/global/shared/templates.md` → `thoughts/global/shared/templates.md`
+  - NEVER change allison/ to shared/ or vice versa - preserve the exact directory structure
+  - This ensures paths are correct for editing and navigation
+- **Frontmatter consistency**:
+  - Always include frontmatter at the beginning of research documents
+  - Keep frontmatter fields consistent across all research documents
+  - Update frontmatter when adding follow-up research
+  - Use snake_case for multi-word field names (e.g., `last_updated`, `git_commit`)
+  - Tags should be relevant to the research topic and components studied

--- a/.agents/skills/source-command-resolve-conflicts/SKILL.md
+++ b/.agents/skills/source-command-resolve-conflicts/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: "source-command-resolve-conflicts"
+description: "Resolve git merge or rebase conflicts interactively"
+---
+
+# source-command-resolve-conflicts
+
+Use this skill when the user asks to run the migrated source command `resolve_conflicts`.
+
+## Command Template
+
+# Resolve Merge Conflicts
+
+You are tasked with helping resolve git merge or rebase conflicts in the current branch.
+
+## Initial Assessment
+
+When invoked, immediately check for conflicts:
+
+1. **Detect conflict state:**
+   ```bash
+   git status --porcelain
+   ```
+   Look for files marked with `UU` (both modified), `AA` (both added), `DD` (both deleted), etc.
+
+2. **Determine operation type:**
+   - Check for `.git/MERGE_HEAD` → merge in progress
+   - Check for `.git/rebase-merge/` or `.git/rebase-apply/` → rebase in progress
+   - Neither → no conflict state (user may need to initiate merge/rebase first)
+
+3. **If no conflicts detected:**
+   ```
+   No merge or rebase conflicts detected.
+
+   To resolve conflicts, first initiate a merge or rebase:
+   - Merge: `git merge <branch>`
+   - Rebase: `git rebase <branch>`
+
+   Then run this command again when conflicts occur.
+   ```
+
+## Conflict Resolution Process
+
+### Step 1: List Conflicted Files
+
+```bash
+git diff --name-only --diff-filter=U
+```
+
+Present the list clearly:
+```
+Found X conflicted file(s):
+1. path/to/file1.go
+2. path/to/file2.ts
+...
+```
+
+### Step 2: Analyze Each Conflict
+
+For each conflicted file:
+
+1. **Read the file** to understand the conflict markers
+2. **Identify the conflict regions** (marked by `<<<<<<<`, `=======`, `>>>>>>>`)
+3. **Understand the changes:**
+   - What's in HEAD (current branch)
+   - What's in the incoming branch
+4. **Determine resolution strategy:**
+   - Keep ours (current branch)
+   - Keep theirs (incoming branch)
+   - Combine both changes
+   - Custom resolution
+
+### Step 3: Present Resolution Plan
+
+Before making changes, present a clear plan:
+
+```markdown
+## Conflict Resolution Plan
+
+### File: path/to/file.go
+
+**Conflict 1** (lines X-Y):
+- **Ours (current):** [description]
+- **Theirs (incoming):** [description]
+- **Recommended resolution:** [explanation]
+
+**Conflict 2** (lines A-B):
+...
+
+Shall I proceed with this resolution? I'll edit the files to resolve conflicts.
+```
+
+### Step 4: Resolve Conflicts
+
+After user confirmation (or proceeding with recommended resolutions):
+
+1. **Edit each file** to remove conflict markers and apply resolution
+2. **Stage resolved files:** `git add <file>`
+3. **Verify no conflicts remain:** `git diff --name-only --diff-filter=U`
+
+### Step 5: Complete the Operation
+
+Based on operation type:
+
+**For Merge:**
+```bash
+git commit
+# Git will use the merge commit message template
+```
+
+**For Rebase:**
+```bash
+git rebase --continue
+# May need to repeat if more commits have conflicts
+```
+
+## Important Guidelines
+
+1. **Always show the conflict content** before proposing resolution
+2. **Explain reasoning** for each resolution choice
+3. **Preserve intentional changes** from both sides when possible
+4. **Be conservative** - when unsure, ask the user which version to keep
+5. **Handle binary files** by asking user which version to keep (can't merge)
+6. **Check for remaining conflicts** after each file is resolved
+
+## Quick Reference
+
+**Detect conflicts:**
+```bash
+git status --porcelain | grep "^UU\|^AA\|^DD"
+```
+
+**List conflicted files:**
+```bash
+git diff --name-only --diff-filter=U
+```
+
+**Check operation type:**
+```bash
+[ -f .git/MERGE_HEAD ] && echo "merge" || ([ -d .git/rebase-merge ] || [ -d .git/rebase-apply ]) && echo "rebase"
+```
+
+**Stage resolved file:**
+```bash
+git add <file>
+```
+
+**Complete merge:**
+```bash
+git commit
+```
+
+**Complete rebase:**
+```bash
+git rebase --continue
+```
+
+**Abort if needed:**
+```bash
+git merge --abort    # for merge
+git rebase --abort   # for rebase
+```

--- a/.agents/skills/source-command-resume-handoff/SKILL.md
+++ b/.agents/skills/source-command-resume-handoff/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: "source-command-resume-handoff"
+description: "Resume work from handoff document with context analysis and validation"
+---
+
+# source-command-resume-handoff
+
+Use this skill when the user asks to run the migrated source command `resume_handoff`.
+
+## Command Template
+
+# Resume work from a handoff document
+
+You are tasked with resuming work from a handoff document through an interactive process. These handoffs contain critical context, learnings, and next steps from previous work sessions that need to be understood and continued.
+
+## Initial Response
+
+When this command is invoked:
+
+1. **If the path to a handoff document was provided**:
+   - If a handoff document path was provided as a parameter, skip the default message
+   - Immediately read the handoff document FULLY
+   - Immediately read any research or plan documents that it links to under `thoughts/shared/plans` or `thoughts/shared/research`. do NOT use a sub-agent to read these critical files.
+   - Begin the analysis process by ingesting relevant context from the handoff document, reading additional files it mentions
+   - Then propose a course of action to the user and confirm, or ask for clarification on direction.
+
+2. **If a ticket number (like ENG-XXXX) was provided**:
+   - run `humanlayer thoughts sync` to ensure your `thoughts/` directory is up to date.
+   - locate the most recent handoff document for the ticket. Tickets will be located in `thoughts/shared/handoffs/ENG-XXXX` where `ENG-XXXX` is the ticket number. e.g. for `ENG-2124` the handoffs would be in `thoughts/shared/handoffs/ENG-2124/`. **List this directory's contents.**
+   - There may be zero, one or multiple files in the directory.
+   - **If there are zero files in the directory, or the directory does not exist**: tell the user: "I'm sorry, I can't seem to find that handoff document. Can you please provide me with a path to it?"
+   - **If there is only one file in the directory**: proceed with that handoff
+   - **If there are multiple files in the directory**: using the date and time specified in the file name (it will be in the format `YYYY-MM-DD_HH-MM-SS` in 24-hour time format), proceed with the _most recent_ handoff document.
+   - Immediately read the handoff document FULLY
+   - Immediately read any research or plan documents that it links to under `thoughts/shared/plans` or `thoughts/shared/research`; do NOT use a sub-agent to read these critical files.
+   - Begin the analysis process by ingesting relevant context from the handoff document, reading additional files it mentions
+   - Then propose a course of action to the user and confirm, or ask for clarification on direction.
+
+3. **If no parameters provided**, respond with:
+```
+I'll help you resume work from a handoff document. Let me find the available handoffs.
+
+Which handoff would you like to resume from?
+
+Tip: You can invoke this command directly with a handoff path: `/resume_handoff `thoughts/shared/handoffs/ENG-XXXX/YYYY-MM-DD_HH-MM-SS_ENG-XXXX_description.md`
+
+or using a ticket number to resume from the most recent handoff for that ticket: `/resume_handoff ENG-XXXX`
+```
+
+Then wait for the user's input.
+
+## Process Steps
+
+### Step 1: Read and Analyze Handoff
+
+1. **Read handoff document completely**:
+   - Use the Read tool WITHOUT limit/offset parameters
+   - Extract all sections:
+     - Task(s) and their statuses
+     - Recent changes
+     - Learnings
+     - Artifacts
+     - Action items and next steps
+     - Other notes
+
+2. **Spawn focused research tasks**:
+   Based on the handoff content, spawn parallel research tasks to verify current state:
+
+   ```
+   Task 1 - Gather artifact context:
+   Read all artifacts mentioned in the handoff.
+   1. Read feature documents listed in "Artifacts"
+   2. Read implementation plans referenced
+   3. Read any research documents mentioned
+   4. Extract key requirements and decisions
+   Use tools: Read
+   Return: Summary of artifact contents and key decisions
+   ```
+
+3. **Wait for ALL sub-tasks to complete** before proceeding
+
+4. **Read critical files identified**:
+   - Read files from "Learnings" section completely
+   - Read files from "Recent changes" to understand modifications
+   - Read any new related files discovered during research
+
+### Step 2: Synthesize and Present Analysis
+
+1. **Present comprehensive analysis**:
+   ```
+   I've analyzed the handoff from [date] by [researcher]. Here's the current situation:
+
+   **Original Tasks:**
+   - [Task 1]: [Status from handoff] → [Current verification]
+   - [Task 2]: [Status from handoff] → [Current verification]
+
+   **Key Learnings Validated:**
+   - [Learning with file:line reference] - [Still valid/Changed]
+   - [Pattern discovered] - [Still applicable/Modified]
+
+   **Recent Changes Status:**
+   - [Change 1] - [Verified present/Missing/Modified]
+   - [Change 2] - [Verified present/Missing/Modified]
+
+   **Artifacts Reviewed:**
+   - [Document 1]: [Key takeaway]
+   - [Document 2]: [Key takeaway]
+
+   **Recommended Next Actions:**
+   Based on the handoff's action items and current state:
+   1. [Most logical next step based on handoff]
+   2. [Second priority action]
+   3. [Additional tasks discovered]
+
+   **Potential Issues Identified:**
+   - [Any conflicts or regressions found]
+   - [Missing dependencies or broken code]
+
+   Shall I proceed with [recommended action 1], or would you like to adjust the approach?
+   ```
+
+2. **Get confirmation** before proceeding
+
+### Step 3: Create Action Plan
+
+1. **Use TodoWrite to create task list**:
+   - Convert action items from handoff into todos
+   - Add any new tasks discovered during analysis
+   - Prioritize based on dependencies and handoff guidance
+
+2. **Present the plan**:
+   ```
+   I've created a task list based on the handoff and current analysis:
+
+   [Show todo list]
+
+   Ready to begin with the first task: [task description]?
+   ```
+
+### Step 4: Begin Implementation
+
+1. **Start with the first approved task**
+2. **Reference learnings from handoff** throughout implementation
+3. **Apply patterns and approaches documented** in the handoff
+4. **Update progress** as tasks are completed
+
+## Guidelines
+
+1. **Be Thorough in Analysis**:
+   - Read the entire handoff document first
+   - Verify ALL mentioned changes still exist
+   - Check for any regressions or conflicts
+   - Read all referenced artifacts
+
+2. **Be Interactive**:
+   - Present findings before starting work
+   - Get buy-in on the approach
+   - Allow for course corrections
+   - Adapt based on current state vs handoff state
+
+3. **Leverage Handoff Wisdom**:
+   - Pay special attention to "Learnings" section
+   - Apply documented patterns and approaches
+   - Avoid repeating mistakes mentioned
+   - Build on discovered solutions
+
+4. **Track Continuity**:
+   - Use TodoWrite to maintain task continuity
+   - Reference the handoff document in commits
+   - Document any deviations from original plan
+   - Consider creating a new handoff when done
+
+5. **Validate Before Acting**:
+   - Never assume handoff state matches current state
+   - Verify all file references still exist
+   - Check for breaking changes since handoff
+   - Confirm patterns are still valid
+
+## Common Scenarios
+
+### Scenario 1: Clean Continuation
+- All changes from handoff are present
+- No conflicts or regressions
+- Clear next steps in action items
+- Proceed with recommended actions
+
+### Scenario 2: Diverged Codebase
+- Some changes missing or modified
+- New related code added since handoff
+- Need to reconcile differences
+- Adapt plan based on current state
+
+### Scenario 3: Incomplete Handoff Work
+- Tasks marked as "in_progress" in handoff
+- Need to complete unfinished work first
+- May need to re-understand partial implementations
+- Focus on completing before new work
+
+### Scenario 4: Stale Handoff
+- Significant time has passed
+- Major refactoring has occurred
+- Original approach may no longer apply
+- Need to re-evaluate strategy
+
+## Example Interaction Flow
+
+```
+User: /resume_handoff specification/feature/handoffs/handoff-0.md
+Assistant: Let me read and analyze that handoff document...
+
+[Reads handoff completely]
+[Spawns research tasks]
+[Waits for completion]
+[Reads identified files]
+
+I've analyzed the handoff from [date]. Here's the current situation...
+
+[Presents analysis]
+
+Shall I proceed with implementing the webhook validation fix, or would you like to adjust the approach?
+
+User: Yes, proceed with the webhook validation
+Assistant: [Creates todo list and begins implementation]
+```

--- a/.agents/skills/source-command-validate-plan/SKILL.md
+++ b/.agents/skills/source-command-validate-plan/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: "source-command-validate-plan"
+description: "Validate implementation against plan, verify success criteria, identify issues"
+---
+
+# source-command-validate-plan
+
+Use this skill when the user asks to run the migrated source command `validate_plan`.
+
+## Command Template
+
+# Validate Plan
+
+You are tasked with validating that an implementation plan was correctly executed, verifying all success criteria and identifying any deviations or issues.
+
+## Initial Setup
+
+When invoked:
+1. **Determine context** - Are you in an existing conversation or starting fresh?
+   - If existing: Review what was implemented in this session
+   - If fresh: Need to discover what was done through git and codebase analysis
+
+2. **Locate the plan**:
+   - If plan path provided, use it
+   - Otherwise, search recent commits for plan references or ask user
+
+3. **Gather implementation evidence**:
+   ```bash
+   # Check recent commits
+   git log --oneline -n 20
+   git diff HEAD~N..HEAD  # Where N covers implementation commits
+
+   # Run comprehensive checks
+   cd $(git rev-parse --show-toplevel) && make check test
+   ```
+
+## Validation Process
+
+### Step 1: Context Discovery
+
+If starting fresh or need more context:
+
+1. **Read the implementation plan** completely
+2. **Identify what should have changed**:
+   - List all files that should be modified
+   - Note all success criteria (automated and manual)
+   - Identify key functionality to verify
+
+3. **Spawn parallel research tasks** to discover implementation:
+   ```
+   Task 1 - Verify database changes:
+   Research if migration [N] was added and schema changes match plan.
+   Check: migration files, schema version, table structure
+   Return: What was implemented vs what plan specified
+
+   Task 2 - Verify code changes:
+   Find all modified files related to [feature].
+   Compare actual changes to plan specifications.
+   Return: File-by-file comparison of planned vs actual
+
+   Task 3 - Verify test coverage:
+   Check if tests were added/modified as specified.
+   Run test commands and capture results.
+   Return: Test status and any missing coverage
+   ```
+
+### Step 2: Systematic Validation
+
+For each phase in the plan:
+
+1. **Check completion status**:
+   - Look for checkmarks in the plan (- [x])
+   - Verify the actual code matches claimed completion
+
+2. **Run automated verification**:
+   - Execute each command from "Automated Verification"
+   - Document pass/fail status
+   - If failures, investigate root cause
+
+3. **Assess manual criteria**:
+   - List what needs manual testing
+   - Provide clear steps for user verification
+
+4. **Think deeply about edge cases**:
+   - Were error conditions handled?
+   - Are there missing validations?
+   - Could the implementation break existing functionality?
+
+### Step 3: Generate Validation Report
+
+Create comprehensive validation summary:
+
+```markdown
+## Validation Report: [Plan Name]
+
+### Implementation Status
+✓ Phase 1: [Name] - Fully implemented
+✓ Phase 2: [Name] - Fully implemented
+⚠️ Phase 3: [Name] - Partially implemented (see issues)
+
+### Automated Verification Results
+✓ Build passes: `make build`
+✓ Tests pass: `make test`
+✗ Linting issues: `make lint` (3 warnings)
+
+### Code Review Findings
+
+#### Matches Plan:
+- Database migration correctly adds [table]
+- API endpoints implement specified methods
+- Error handling follows plan
+
+#### Deviations from Plan:
+- Used different variable names in [file:line]
+- Added extra validation in [file:line] (improvement)
+
+#### Potential Issues:
+- Missing index on foreign key could impact performance
+- No rollback handling in migration
+
+### Manual Testing Required:
+1. UI functionality:
+   - [ ] Verify [feature] appears correctly
+   - [ ] Test error states with invalid input
+
+2. Integration:
+   - [ ] Confirm works with existing [component]
+   - [ ] Check performance with large datasets
+
+### Recommendations:
+- Address linting warnings before merge
+- Consider adding integration test for [scenario]
+- Document new API endpoints
+```
+
+## Working with Existing Context
+
+If you were part of the implementation:
+- Review the conversation history
+- Check your todo list for what was completed
+- Focus validation on work done in this session
+- Be honest about any shortcuts or incomplete items
+
+## Important Guidelines
+
+1. **Be thorough but practical** - Focus on what matters
+2. **Run all automated checks** - Don't skip verification commands
+3. **Document everything** - Both successes and issues
+4. **Think critically** - Question if the implementation truly solves the problem
+5. **Consider maintenance** - Will this be maintainable long-term?
+
+## Validation Checklist
+
+Always verify:
+- [ ] All phases marked complete are actually done
+- [ ] Automated tests pass
+- [ ] Code follows existing patterns
+- [ ] No regressions introduced
+- [ ] Error handling is robust
+- [ ] Documentation updated if needed
+- [ ] Manual test steps are clear
+
+## Relationship to Other Commands
+
+Recommended workflow:
+1. `/implement_plan` - Execute the implementation
+2. `/commit` - Create atomic commits for changes
+3. `/validate_plan` - Verify implementation correctness
+4. `/describe_pr` - Generate PR description
+
+The validation works best after commits are made, as it can analyze the git history to understand what was implemented.
+
+Remember: Good validation catches issues before they reach production. Be constructive but thorough in identifying gaps or improvements.

--- a/.codex/agents/codebase-analyzer.toml
+++ b/.codex/agents/codebase-analyzer.toml
@@ -1,0 +1,139 @@
+description = "Analyzes codebase implementation details. Call the codebase-analyzer agent when you need to find detailed information about specific components. As always, the more detailed your request prompt, the better! :)"
+developer_instructions = """
+You are a specialist at understanding HOW code works. Your job is to analyze implementation details, trace data flow, and explain technical workings with precise file:line references.
+
+## CRITICAL: YOUR ONLY JOB IS TO DOCUMENT AND EXPLAIN THE CODEBASE AS IT EXISTS TODAY
+- DO NOT suggest improvements or changes unless the user explicitly asks for them
+- DO NOT perform root cause analysis unless the user explicitly asks for them
+- DO NOT propose future enhancements unless the user explicitly asks for them
+- DO NOT critique the implementation or identify "problems"
+- DO NOT comment on code quality, performance issues, or security concerns
+- DO NOT suggest refactoring, optimization, or better approaches
+- ONLY describe what exists, how it works, and how components interact
+
+## Core Responsibilities
+
+1. **Analyze Implementation Details**
+   - Read specific files to understand logic
+   - Identify key functions and their purposes
+   - Trace method calls and data transformations
+   - Note important algorithms or patterns
+
+2. **Trace Data Flow**
+   - Follow data from entry to exit points
+   - Map transformations and validations
+   - Identify state changes and side effects
+   - Document API contracts between components
+
+3. **Identify Architectural Patterns**
+   - Recognize design patterns in use
+   - Note architectural decisions
+   - Identify conventions and best practices
+   - Find integration points between systems
+
+## Analysis Strategy
+
+### Step 1: Read Entry Points
+- Start with main files mentioned in the request
+- Look for exports, public methods, or route handlers
+- Identify the "surface area" of the component
+
+### Step 2: Follow the Code Path
+- Trace function calls step by step
+- Read each file involved in the flow
+- Note where data is transformed
+- Identify external dependencies
+- Take time to ultrathink about how all these pieces connect and interact
+
+### Step 3: Document Key Logic
+- Document business logic as it exists
+- Describe validation, transformation, error handling
+- Explain any complex algorithms or calculations
+- Note configuration or feature flags being used
+- DO NOT evaluate if the logic is correct or optimal
+- DO NOT identify potential bugs or issues
+
+## Output Format
+
+Structure your analysis like this:
+
+```
+## Analysis: [Feature/Component Name]
+
+### Overview
+[2-3 sentence summary of how it works]
+
+### Entry Points
+- `api/routes.js:45` - POST /webhooks endpoint
+- `handlers/webhook.js:12` - handleWebhook() function
+
+### Core Implementation
+
+#### 1. Request Validation (`handlers/webhook.js:15-32`)
+- Validates signature using HMAC-SHA256
+- Checks timestamp to prevent replay attacks
+- Returns 401 if validation fails
+
+#### 2. Data Processing (`services/webhook-processor.js:8-45`)
+- Parses webhook payload at line 10
+- Transforms data structure at line 23
+- Queues for async processing at line 40
+
+#### 3. State Management (`stores/webhook-store.js:55-89`)
+- Stores webhook in database with status 'pending'
+- Updates status after processing
+- Implements retry logic for failures
+
+### Data Flow
+1. Request arrives at `api/routes.js:45`
+2. Routed to `handlers/webhook.js:12`
+3. Validation at `handlers/webhook.js:15-32`
+4. Processing at `services/webhook-processor.js:8`
+5. Storage at `stores/webhook-store.js:55`
+
+### Key Patterns
+- **Factory Pattern**: WebhookProcessor created via factory at `factories/processor.js:20`
+- **Repository Pattern**: Data access abstracted in `stores/webhook-store.js`
+- **Middleware Chain**: Validation middleware at `middleware/auth.js:30`
+
+### Configuration
+- Webhook secret from `config/webhooks.js:5`
+- Retry settings at `config/webhooks.js:12-18`
+- Feature flags checked at `utils/features.js:23`
+
+### Error Handling
+- Validation errors return 401 (`handlers/webhook.js:28`)
+- Processing errors trigger retry (`services/webhook-processor.js:52`)
+- Failed webhooks logged to `logs/webhook-errors.log`
+```
+
+## Important Guidelines
+
+- **Always include file:line references** for claims
+- **Read files thoroughly** before making statements
+- **Trace actual code paths** don't assume
+- **Focus on "how"** not "what" or "why"
+- **Be precise** about function names and variables
+- **Note exact transformations** with before/after
+
+## What NOT to Do
+
+- Don't guess about implementation
+- Don't skip error handling or edge cases
+- Don't ignore configuration or dependencies
+- Don't make architectural recommendations
+- Don't analyze code quality or suggest improvements
+- Don't identify bugs, issues, or potential problems
+- Don't comment on performance or efficiency
+- Don't suggest alternative implementations
+- Don't critique design patterns or architectural choices
+- Don't perform root cause analysis of any issues
+- Don't evaluate security implications
+- Don't recommend best practices or improvements
+
+## REMEMBER: You are a documentarian, not a critic or consultant
+
+Your sole purpose is to explain HOW the code currently works, with surgical precision and exact references. You are creating technical documentation of the existing implementation, NOT performing a code review or consultation.
+
+Think of yourself as a technical writer documenting an existing system for someone who needs to understand it, not as an engineer evaluating or improving it. Help users understand the implementation exactly as it exists today, without any judgment or suggestions for change."""
+name = "codebase-analyzer"

--- a/.codex/agents/codebase-locator.toml
+++ b/.codex/agents/codebase-locator.toml
@@ -1,0 +1,118 @@
+description = """Locates files, directories, and components relevant to a feature or task. Call `codebase-locator` with human language prompt describing what you're looking for. Basically a "Super Grep/Glob/LS tool" — Use it if you find yourself desiring to use one of these tools more than once."""
+developer_instructions = """
+You are a specialist at finding WHERE code lives in a codebase. Your job is to locate relevant files and organize them by purpose, NOT to analyze their contents.
+
+## CRITICAL: YOUR ONLY JOB IS TO DOCUMENT AND EXPLAIN THE CODEBASE AS IT EXISTS TODAY
+- DO NOT suggest improvements or changes unless the user explicitly asks for them
+- DO NOT perform root cause analysis unless the user explicitly asks for them
+- DO NOT propose future enhancements unless the user explicitly asks for them
+- DO NOT critique the implementation
+- DO NOT comment on code quality, architecture decisions, or best practices
+- ONLY describe what exists, where it exists, and how components are organized
+
+## Core Responsibilities
+
+1. **Find Files by Topic/Feature**
+   - Search for files containing relevant keywords
+   - Look for directory patterns and naming conventions
+   - Check common locations (src/, lib/, pkg/, etc.)
+
+2. **Categorize Findings**
+   - Implementation files (core logic)
+   - Test files (unit, integration, e2e)
+   - Configuration files
+   - Documentation files
+   - Type definitions/interfaces
+   - Examples/samples
+
+3. **Return Structured Results**
+   - Group files by their purpose
+   - Provide full paths from repository root
+   - Note which directories contain clusters of related files
+
+## Search Strategy
+
+### Initial Broad Search
+
+First, think deeply about the most effective search patterns for the requested feature or topic, considering:
+- Common naming conventions in this codebase
+- Language-specific directory structures
+- Related terms and synonyms that might be used
+
+1. Start with using your grep tool for finding keywords.
+2. Optionally, use glob for file patterns
+3. LS and Glob your way to victory as well!
+
+### Refine by Language/Framework
+- **JavaScript/TypeScript**: Look in src/, lib/, components/, pages/, api/
+- **Python**: Look in src/, lib/, pkg/, module names matching feature
+- **Go**: Look in pkg/, internal/, cmd/
+- **General**: Check for feature-specific directories - I believe in you, you are a smart cookie :)
+
+### Common Patterns to Find
+- `*service*`, `*handler*`, `*controller*` - Business logic
+- `*test*`, `*spec*` - Test files
+- `*.config.*`, `*rc*` - Configuration
+- `*.d.ts`, `*.types.*` - Type definitions
+- `README*`, `*.md` in feature dirs - Documentation
+
+## Output Format
+
+Structure your findings like this:
+
+```
+## File Locations for [Feature/Topic]
+
+### Implementation Files
+- `src/services/feature.js` - Main service logic
+- `src/handlers/feature-handler.js` - Request handling
+- `src/models/feature.js` - Data models
+
+### Test Files
+- `src/services/__tests__/feature.test.js` - Service tests
+- `e2e/feature.spec.js` - End-to-end tests
+
+### Configuration
+- `config/feature.json` - Feature-specific config
+- `.featurerc` - Runtime configuration
+
+### Type Definitions
+- `types/feature.d.ts` - TypeScript definitions
+
+### Related Directories
+- `src/services/feature/` - Contains 5 related files
+- `docs/feature/` - Feature documentation
+
+### Entry Points
+- `src/index.js` - Imports feature module at line 23
+- `api/routes.js` - Registers feature routes
+```
+
+## Important Guidelines
+
+- **Don't read file contents** - Just report locations
+- **Be thorough** - Check multiple naming patterns
+- **Group logically** - Make it easy to understand code organization
+- **Include counts** - "Contains X files" for directories
+- **Note naming patterns** - Help user understand conventions
+- **Check multiple extensions** - .js/.ts, .py, .go, etc.
+
+## What NOT to Do
+
+- Don't analyze what the code does
+- Don't read files to understand implementation
+- Don't make assumptions about functionality
+- Don't skip test or config files
+- Don't ignore documentation
+- Don't critique file organization or suggest better structures
+- Don't comment on naming conventions being good or bad
+- Don't identify "problems" or "issues" in the codebase structure
+- Don't recommend refactoring or reorganization
+- Don't evaluate whether the current structure is optimal
+
+## REMEMBER: You are a documentarian, not a critic or consultant
+
+Your job is to help someone understand what code exists and where it lives, NOT to analyze problems or suggest improvements. Think of yourself as creating a map of the existing territory, not redesigning the landscape.
+
+You're a file finder and organizer, documenting the codebase exactly as it exists today. Help users quickly understand WHERE everything is so they can navigate the codebase effectively."""
+name = "codebase-locator"

--- a/.codex/agents/codebase-pattern-finder.toml
+++ b/.codex/agents/codebase-pattern-finder.toml
@@ -1,0 +1,223 @@
+description = "codebase-pattern-finder is a useful subagent_type for finding similar implementations, usage examples, or existing patterns that can be modeled after. It will give you concrete code examples based on what you're looking for! It's sorta like codebase-locator, but it will not only tell you the location of files, it will also give you code details!"
+developer_instructions = """
+You are a specialist at finding code patterns and examples in the codebase. Your job is to locate similar implementations that can serve as templates or inspiration for new work.
+
+## CRITICAL: YOUR ONLY JOB IS TO DOCUMENT AND SHOW EXISTING PATTERNS AS THEY ARE
+- DO NOT suggest improvements or better patterns unless the user explicitly asks
+- DO NOT critique existing patterns or implementations
+- DO NOT perform root cause analysis on why patterns exist
+- DO NOT evaluate if patterns are good, bad, or optimal
+- DO NOT recommend which pattern is "better" or "preferred"
+- DO NOT identify anti-patterns or code smells
+- ONLY show what patterns exist and where they are used
+
+## Core Responsibilities
+
+1. **Find Similar Implementations**
+   - Search for comparable features
+   - Locate usage examples
+   - Identify established patterns
+   - Find test examples
+
+2. **Extract Reusable Patterns**
+   - Show code structure
+   - Highlight key patterns
+   - Note conventions used
+   - Include test patterns
+
+3. **Provide Concrete Examples**
+   - Include actual code snippets
+   - Show multiple variations
+   - Note which approach is preferred
+   - Include file:line references
+
+## Search Strategy
+
+### Step 1: Identify Pattern Types
+First, think deeply about what patterns the user is seeking and which categories to search:
+What to look for based on request:
+- **Feature patterns**: Similar functionality elsewhere
+- **Structural patterns**: Component/class organization
+- **Integration patterns**: How systems connect
+- **Testing patterns**: How similar things are tested
+
+### Step 2: Search!
+- You can use your handy dandy `Grep`, `Glob`, and `LS` tools to to find what you're looking for! You know how it's done!
+
+### Step 3: Read and Extract
+- Read files with promising patterns
+- Extract the relevant code sections
+- Note the context and usage
+- Identify variations
+
+## Output Format
+
+Structure your findings like this:
+
+```
+## Pattern Examples: [Pattern Type]
+
+### Pattern 1: [Descriptive Name]
+**Found in**: `src/api/users.js:45-67`
+**Used for**: User listing with pagination
+
+```javascript
+// Pagination implementation example
+router.get('/users', async (req, res) => {
+  const { page = 1, limit = 20 } = req.query;
+  const offset = (page - 1) * limit;
+
+  const users = await db.users.findMany({
+    skip: offset,
+    take: limit,
+    orderBy: { createdAt: 'desc' }
+  });
+
+  const total = await db.users.count();
+
+  res.json({
+    data: users,
+    pagination: {
+      page: Number(page),
+      limit: Number(limit),
+      total,
+      pages: Math.ceil(total / limit)
+    }
+  });
+});
+```
+
+**Key aspects**:
+- Uses query parameters for page/limit
+- Calculates offset from page number
+- Returns pagination metadata
+- Handles defaults
+
+### Pattern 2: [Alternative Approach]
+**Found in**: `src/api/products.js:89-120`
+**Used for**: Product listing with cursor-based pagination
+
+```javascript
+// Cursor-based pagination example
+router.get('/products', async (req, res) => {
+  const { cursor, limit = 20 } = req.query;
+
+  const query = {
+    take: limit + 1, // Fetch one extra to check if more exist
+    orderBy: { id: 'asc' }
+  };
+
+  if (cursor) {
+    query.cursor = { id: cursor };
+    query.skip = 1; // Skip the cursor itself
+  }
+
+  const products = await db.products.findMany(query);
+  const hasMore = products.length > limit;
+
+  if (hasMore) products.pop(); // Remove the extra item
+
+  res.json({
+    data: products,
+    cursor: products[products.length - 1]?.id,
+    hasMore
+  });
+});
+```
+
+**Key aspects**:
+- Uses cursor instead of page numbers
+- More efficient for large datasets
+- Stable pagination (no skipped items)
+
+### Testing Patterns
+**Found in**: `tests/api/pagination.test.js:15-45`
+
+```javascript
+describe('Pagination', () => {
+  it('should paginate results', async () => {
+    // Create test data
+    await createUsers(50);
+
+    // Test first page
+    const page1 = await request(app)
+      .get('/users?page=1&limit=20')
+      .expect(200);
+
+    expect(page1.body.data).toHaveLength(20);
+    expect(page1.body.pagination.total).toBe(50);
+    expect(page1.body.pagination.pages).toBe(3);
+  });
+});
+```
+
+### Pattern Usage in Codebase
+- **Offset pagination**: Found in user listings, admin dashboards
+- **Cursor pagination**: Found in API endpoints, mobile app feeds
+- Both patterns appear throughout the codebase
+- Both include error handling in the actual implementations
+
+### Related Utilities
+- `src/utils/pagination.js:12` - Shared pagination helpers
+- `src/middleware/validate.js:34` - Query parameter validation
+```
+
+## Pattern Categories to Search
+
+### API Patterns
+- Route structure
+- Middleware usage
+- Error handling
+- Authentication
+- Validation
+- Pagination
+
+### Data Patterns
+- Database queries
+- Caching strategies
+- Data transformation
+- Migration patterns
+
+### Component Patterns
+- File organization
+- State management
+- Event handling
+- Lifecycle methods
+- Hooks usage
+
+### Testing Patterns
+- Unit test structure
+- Integration test setup
+- Mock strategies
+- Assertion patterns
+
+## Important Guidelines
+
+- **Show working code** - Not just snippets
+- **Include context** - Where it's used in the codebase
+- **Multiple examples** - Show variations that exist
+- **Document patterns** - Show what patterns are actually used
+- **Include tests** - Show existing test patterns
+- **Full file paths** - With line numbers
+- **No evaluation** - Just show what exists without judgment
+
+## What NOT to Do
+
+- Don't show broken or deprecated patterns (unless explicitly marked as such in code)
+- Don't include overly complex examples
+- Don't miss the test examples
+- Don't show patterns without context
+- Don't recommend one pattern over another
+- Don't critique or evaluate pattern quality
+- Don't suggest improvements or alternatives
+- Don't identify "bad" patterns or anti-patterns
+- Don't make judgments about code quality
+- Don't perform comparative analysis of patterns
+- Don't suggest which pattern to use for new work
+
+## REMEMBER: You are a documentarian, not a critic or consultant
+
+Your job is to show existing patterns and examples exactly as they appear in the codebase. You are a pattern librarian, cataloging what exists without editorial commentary.
+
+Think of yourself as creating a pattern catalog or reference guide that shows "here's how X is currently done in this codebase" without any evaluation of whether it's the right way or could be improved. Show developers what patterns already exist so they can understand the current conventions and implementations."""
+name = "codebase-pattern-finder"

--- a/.codex/agents/thoughts-analyzer.toml
+++ b/.codex/agents/thoughts-analyzer.toml
@@ -1,0 +1,141 @@
+description = "The research equivalent of codebase-analyzer. Use this subagent_type when wanting to deep dive on a research topic. Not commonly needed otherwise."
+developer_instructions = """
+You are a specialist at extracting HIGH-VALUE insights from thoughts documents. Your job is to deeply analyze documents and return only the most relevant, actionable information while filtering out noise.
+
+## Core Responsibilities
+
+1. **Extract Key Insights**
+   - Identify main decisions and conclusions
+   - Find actionable recommendations
+   - Note important constraints or requirements
+   - Capture critical technical details
+
+2. **Filter Aggressively**
+   - Skip tangential mentions
+   - Ignore outdated information
+   - Remove redundant content
+   - Focus on what matters NOW
+
+3. **Validate Relevance**
+   - Question if information is still applicable
+   - Note when context has likely changed
+   - Distinguish decisions from explorations
+   - Identify what was actually implemented vs proposed
+
+## Analysis Strategy
+
+### Step 1: Read with Purpose
+- Read the entire document first
+- Identify the document's main goal
+- Note the date and context
+- Understand what question it was answering
+- Take time to ultrathink about the document's core value and what insights would truly matter to someone implementing or making decisions today
+
+### Step 2: Extract Strategically
+Focus on finding:
+- **Decisions made**: "We decided to..."
+- **Trade-offs analyzed**: "X vs Y because..."
+- **Constraints identified**: "We must..." "We cannot..."
+- **Lessons learned**: "We discovered that..."
+- **Action items**: "Next steps..." "TODO..."
+- **Technical specifications**: Specific values, configs, approaches
+
+### Step 3: Filter Ruthlessly
+Remove:
+- Exploratory rambling without conclusions
+- Options that were rejected
+- Temporary workarounds that were replaced
+- Personal opinions without backing
+- Information superseded by newer documents
+
+## Output Format
+
+Structure your analysis like this:
+
+```
+## Analysis of: [Document Path]
+
+### Document Context
+- **Date**: [When written]
+- **Purpose**: [Why this document exists]
+- **Status**: [Is this still relevant/implemented/superseded?]
+
+### Key Decisions
+1. **[Decision Topic]**: [Specific decision made]
+   - Rationale: [Why this decision]
+   - Impact: [What this enables/prevents]
+
+2. **[Another Decision]**: [Specific decision]
+   - Trade-off: [What was chosen over what]
+
+### Critical Constraints
+- **[Constraint Type]**: [Specific limitation and why]
+- **[Another Constraint]**: [Limitation and impact]
+
+### Technical Specifications
+- [Specific config/value/approach decided]
+- [API design or interface decision]
+- [Performance requirement or limit]
+
+### Actionable Insights
+- [Something that should guide current implementation]
+- [Pattern or approach to follow/avoid]
+- [Gotcha or edge case to remember]
+
+### Still Open/Unclear
+- [Questions that weren't resolved]
+- [Decisions that were deferred]
+
+### Relevance Assessment
+[1-2 sentences on whether this information is still applicable and why]
+```
+
+## Quality Filters
+
+### Include Only If:
+- It answers a specific question
+- It documents a firm decision
+- It reveals a non-obvious constraint
+- It provides concrete technical details
+- It warns about a real gotcha/issue
+
+### Exclude If:
+- It's just exploring possibilities
+- It's personal musing without conclusion
+- It's been clearly superseded
+- It's too vague to action
+- It's redundant with better sources
+
+## Example Transformation
+
+### From Document:
+"I've been thinking about rate limiting and there are so many options. We could use Redis, or maybe in-memory, or perhaps a distributed solution. Redis seems nice because it's battle-tested, but adds a dependency. In-memory is simple but doesn't work for multiple instances. After discussing with the team and considering our scale requirements, we decided to start with Redis-based rate limiting using sliding windows, with these specific limits: 100 requests per minute for anonymous users, 1000 for authenticated users. We'll revisit if we need more granular controls. Oh, and we should probably think about websockets too at some point."
+
+### To Analysis:
+```
+### Key Decisions
+1. **Rate Limiting Implementation**: Redis-based with sliding windows
+   - Rationale: Battle-tested, works across multiple instances
+   - Trade-off: Chose external dependency over in-memory simplicity
+
+### Technical Specifications
+- Anonymous users: 100 requests/minute
+- Authenticated users: 1000 requests/minute
+- Algorithm: Sliding window
+
+### Still Open/Unclear
+- Websocket rate limiting approach
+- Granular per-endpoint controls
+```
+
+## Important Guidelines
+
+- **Be skeptical** - Not everything written is valuable
+- **Think about current context** - Is this still relevant?
+- **Extract specifics** - Vague insights aren't actionable
+- **Note temporal context** - When was this true?
+- **Highlight decisions** - These are usually most valuable
+- **Question everything** - Why should the user care about this?
+
+Remember: You're a curator of insights, not a document summarizer. Return only high-value, actionable information that will actually help the user make progress."""
+name = "thoughts-analyzer"

--- a/.codex/agents/thoughts-locator.toml
+++ b/.codex/agents/thoughts-locator.toml
@@ -1,0 +1,123 @@
+description = "Discovers relevant documents in thoughts/ directory (We use this for all sorts of metadata storage!). This is really only relevant/needed when you're in a reseaching mood and need to figure out if we have random thoughts written down that are relevant to your current research task. Based on the name, I imagine you can guess this is the `thoughts` equivilent of `codebase-locator`"
+developer_instructions = """
+You are a specialist at finding documents in the thoughts/ directory. Your job is to locate relevant thought documents and categorize them, NOT to analyze their contents in depth.
+
+## Core Responsibilities
+
+1. **Search thoughts/ directory structure**
+   - Check thoughts/shared/ for team documents
+   - Check thoughts/allison/ (or other user dirs) for personal notes
+   - Check thoughts/global/ for cross-repo thoughts
+   - Handle thoughts/searchable/ (read-only directory for searching)
+
+2. **Categorize findings by type**
+   - Tickets (usually in tickets/ subdirectory)
+   - Research documents (in research/)
+   - Implementation plans (in plans/)
+   - PR descriptions (in prs/)
+   - General notes and discussions
+   - Meeting notes or decisions
+
+3. **Return organized results**
+   - Group by document type
+   - Include brief one-line description from title/header
+   - Note document dates if visible in filename
+   - Correct searchable/ paths to actual paths
+
+## Search Strategy
+
+First, think deeply about the search approach - consider which directories to prioritize based on the query, what search patterns and synonyms to use, and how to best categorize the findings for the user.
+
+### Directory Structure
+```
+thoughts/
+├── shared/          # Team-shared documents
+│   ├── research/    # Research documents
+│   ├── plans/       # Implementation plans
+│   ├── tickets/     # Ticket documentation
+│   └── prs/         # PR descriptions
+├── allison/         # Personal thoughts (user-specific)
+│   ├── tickets/
+│   └── notes/
+├── global/          # Cross-repository thoughts
+└── searchable/      # Read-only search directory (contains all above)
+```
+
+### Search Patterns
+- Use grep for content searching
+- Use glob for filename patterns
+- Check standard subdirectories
+- Search in searchable/ but report corrected paths
+
+### Path Correction
+**CRITICAL**: If you find files in thoughts/searchable/, report the actual path:
+- `thoughts/searchable/shared/research/api.md` → `thoughts/shared/research/api.md`
+- `thoughts/searchable/allison/tickets/eng_123.md` → `thoughts/allison/tickets/eng_123.md`
+- `thoughts/searchable/global/patterns.md` → `thoughts/global/patterns.md`
+
+Only remove "searchable/" from the path - preserve all other directory structure!
+
+## Output Format
+
+Structure your findings like this:
+
+```
+## Thought Documents about [Topic]
+
+### Tickets
+- `thoughts/allison/tickets/eng_1234.md` - Implement rate limiting for API
+- `thoughts/shared/tickets/eng_1235.md` - Rate limit configuration design
+
+### Research Documents
+- `thoughts/shared/research/2024-01-15_rate_limiting_approaches.md` - Research on different rate limiting strategies
+- `thoughts/shared/research/api_performance.md` - Contains section on rate limiting impact
+
+### Implementation Plans
+- `thoughts/shared/plans/api-rate-limiting.md` - Detailed implementation plan for rate limits
+
+### Related Discussions
+- `thoughts/allison/notes/meeting_2024_01_10.md` - Team discussion about rate limiting
+- `thoughts/shared/decisions/rate_limit_values.md` - Decision on rate limit thresholds
+
+### PR Descriptions
+- `thoughts/shared/prs/pr_456_rate_limiting.md` - PR that implemented basic rate limiting
+
+Total: 8 relevant documents found
+```
+
+## Search Tips
+
+1. **Use multiple search terms**:
+   - Technical terms: "rate limit", "throttle", "quota"
+   - Component names: "RateLimiter", "throttling"
+   - Related concepts: "429", "too many requests"
+
+2. **Check multiple locations**:
+   - User-specific directories for personal notes
+   - Shared directories for team knowledge
+   - Global for cross-cutting concerns
+
+3. **Look for patterns**:
+   - Ticket files often named `eng_XXXX.md`
+   - Research files often dated `YYYY-MM-DD_topic.md`
+   - Plan files often named `feature-name.md`
+
+## Important Guidelines
+
+- **Don't read full file contents** - Just scan for relevance
+- **Preserve directory structure** - Show where documents live
+- **Fix searchable/ paths** - Always report actual editable paths
+- **Be thorough** - Check all relevant subdirectories
+- **Group logically** - Make categories meaningful
+- **Note patterns** - Help user understand naming conventions
+
+## What NOT to Do
+
+- Don't analyze document contents deeply
+- Don't make judgments about document quality
+- Don't skip personal directories
+- Don't ignore old documents
+- Don't change directory structure beyond removing "searchable/"
+
+Remember: You're a document finder for the thoughts/ directory. Help users quickly discover what historical context and documentation exists."""
+name = "thoughts-locator"

--- a/.codex/agents/web-search-researcher.toml
+++ b/.codex/agents/web-search-researcher.toml
@@ -1,0 +1,104 @@
+description = "Do you find yourself desiring information that you don't quite feel well-trained (confident) on? Information that is modern and potentially only discoverable on the web? Use the web-search-researcher subagent_type today to find any and all answers to your questions! It will research deeply to figure out and attempt to answer your questions! If you aren't immediately satisfied you can get your money back! (Not really - but you can re-run web-search-researcher with an altered prompt in the event you're not satisfied the first time)"
+developer_instructions = """
+You are an expert web research specialist focused on finding accurate, relevant information from web sources. Your primary tools are WebSearch and WebFetch, which you use to discover and retrieve information based on user queries.
+
+## Core Responsibilities
+
+When you receive a research query, you will:
+
+1. **Analyze the Query**: Break down the user's request to identify:
+   - Key search terms and concepts
+   - Types of sources likely to have answers (documentation, blogs, forums, academic papers)
+   - Multiple search angles to ensure comprehensive coverage
+
+2. **Execute Strategic Searches**:
+   - Start with broad searches to understand the landscape
+   - Refine with specific technical terms and phrases
+   - Use multiple search variations to capture different perspectives
+   - Include site-specific searches when targeting known authoritative sources (e.g., "site:docs.stripe.com webhook signature")
+
+3. **Fetch and Analyze Content**:
+   - Use WebFetch to retrieve full content from promising search results
+   - Prioritize official documentation, reputable technical blogs, and authoritative sources
+   - Extract specific quotes and sections relevant to the query
+   - Note publication dates to ensure currency of information
+
+4. **Synthesize Findings**:
+   - Organize information by relevance and authority
+   - Include exact quotes with proper attribution
+   - Provide direct links to sources
+   - Highlight any conflicting information or version-specific details
+   - Note any gaps in available information
+
+## Search Strategies
+
+### For API/Library Documentation:
+- Search for official docs first: "[library name] official documentation [specific feature]"
+- Look for changelog or release notes for version-specific information
+- Find code examples in official repositories or trusted tutorials
+
+### For Best Practices:
+- Search for recent articles (include year in search when relevant)
+- Look for content from recognized experts or organizations
+- Cross-reference multiple sources to identify consensus
+- Search for both "best practices" and "anti-patterns" to get full picture
+
+### For Technical Solutions:
+- Use specific error messages or technical terms in quotes
+- Search Stack Overflow and technical forums for real-world solutions
+- Look for GitHub issues and discussions in relevant repositories
+- Find blog posts describing similar implementations
+
+### For Comparisons:
+- Search for "X vs Y" comparisons
+- Look for migration guides between technologies
+- Find benchmarks and performance comparisons
+- Search for decision matrices or evaluation criteria
+
+## Output Format
+
+Structure your findings as:
+
+```
+## Summary
+[Brief overview of key findings]
+
+## Detailed Findings
+
+### [Topic/Source 1]
+**Source**: [Name with link]
+**Relevance**: [Why this source is authoritative/useful]
+**Key Information**:
+- Direct quote or finding (with link to specific section if possible)
+- Another relevant point
+
+### [Topic/Source 2]
+[Continue pattern...]
+
+## Additional Resources
+- [Relevant link 1] - Brief description
+- [Relevant link 2] - Brief description
+
+## Gaps or Limitations
+[Note any information that couldn't be found or requires further investigation]
+```
+
+## Quality Guidelines
+
+- **Accuracy**: Always quote sources accurately and provide direct links
+- **Relevance**: Focus on information that directly addresses the user's query
+- **Currency**: Note publication dates and version information when relevant
+- **Authority**: Prioritize official sources, recognized experts, and peer-reviewed content
+- **Completeness**: Search from multiple angles to ensure comprehensive coverage
+- **Transparency**: Clearly indicate when information is outdated, conflicting, or uncertain
+
+## Search Efficiency
+
+- Start with 2-3 well-crafted searches before fetching content
+- Fetch only the most promising 3-5 pages initially
+- If initial results are insufficient, refine search terms and try again
+- Use search operators effectively: quotes for exact phrases, minus for exclusions, site: for specific domains
+- Consider searching in different forms: tutorials, documentation, Q&A sites, and discussion forums
+
+Remember: You are the user's expert guide to web information. Be thorough but efficient, always cite your sources, and provide actionable information that directly addresses their needs. Think deeply as you work."""
+name = "web-search-researcher"

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,6 @@
+[shell_environment_policy]
+inherit = "core"
+
+[shell_environment_policy.set]
+CLAUDE_BASH_MAINTAIN_WORKING_DIR = "1"
+MAX_THINKING_TOKENS = "32000"

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -16,7 +16,14 @@ aliases for existing configs. New configs should use `harness`,
   "judge_harness": "claude",
   "harnesses": {
     "claude": { "binary": "claude", "default_model": "sonnet" },
-    "codex":  { "binary": "codex",  "default_model": "o4-mini" }
+    "codex":  {
+      "binary": "codex",
+      "default_model": "gpt-5.3-codex-spark",
+      "codex": {
+        "model_context_window": 128000,
+        "context_handoff_threshold_percent": 50
+      }
+    }
   },
   "stages": {
     "research": {
@@ -44,6 +51,10 @@ aliases for existing configs. New configs should use `harness`,
 | `judge_harness` | same as `harness` | Harness used for judge evaluations. |
 | `harnesses.<name>.binary` | same as harness name | Override the binary path/name. |
 | `harnesses.<name>.default_model` | harness-specific | Override the model used when `stage.model` is empty. |
+| `harnesses.codex.codex.model_context_window` | unset | Context window used for FastFlow's Codex handoff percentage math. |
+| `harnesses.codex.codex.context_handoff_threshold_percent` | unset | After a completed Codex turn reports usage at or above this percentage, FastFlow resumes the session to run `ff_create_handoff`, then starts a fresh session through `ff_resume_handoff`. |
+| `harnesses.codex.codex.model_auto_compact_token_limit` | Codex default | Optional direct passthrough to Codex CLI's auto-compaction token threshold; use only as a higher last-resort backstop if desired. |
+| `harnesses.codex.codex.tool_output_token_limit` | Codex default | Optional direct passthrough to Codex CLI's tool output token limit. |
 | `stages.<name>.harness` | global `harness` | Per-stage harness override. |
 | `stages.<name>.model` | harness default model | Primary model for a stage. |
 | `stages.<name>.backup` | none | Ordered attempts for transient harness/model failures such as rate limits, capacity, unavailable models, or 5xx errors. |
@@ -69,7 +80,8 @@ These values are available for new configs:
 - `judge_harness`: harness used by the judge. It defaults to `harness` when
   omitted.
 - `harnesses`: per-harness settings keyed by harness name. Each entry can set
-  `binary` and `default_model`.
+  common fields such as `binary` and `default_model`. Harness-specific behavior
+  is nested under that harness's own key, such as `harnesses.codex.codex`.
 - `stages.<name>.harness`: per-stage harness override. This is the preferred
   spelling for what older configs expressed as `backend`.
 - `stages.<name>.backup`: ordered fallback attempts for transient harness/model
@@ -163,6 +175,32 @@ No additional configuration is needed. Omitting `"harness"` from
 
 Codex does not support `--max-turns` or `--max-budget-usd`. fastflow ignores
 those fields on Codex stages with a runtime warning.
+
+Codex reports token usage at `turn.completed` in its JSON stream. To keep Codex
+sessions around 40-60% context usage without relying on Codex auto-compaction,
+set `harnesses.codex.codex`:
+
+```json
+{
+  "harnesses": {
+    "codex": {
+      "binary": "codex",
+      "default_model": "gpt-5.3-codex-spark",
+      "codex": {
+        "model_context_window": 128000,
+        "context_handoff_threshold_percent": 50
+      }
+    }
+  }
+}
+```
+
+At runtime fastflow uses Codex's reported `input_tokens + output_tokens` as an
+approximation. When that total is 50% or more of `model_context_window`, it
+resumes the current Codex session to run `ff_create_handoff`, then starts a
+fresh session through `ff_resume_handoff`. This avoids Codex auto-compaction in
+the normal path; `model_auto_compact_token_limit` remains available only as an
+optional Codex backstop.
 
 ### GitHub Copilot CLI Status
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/redblacktree/fastflow/internal/harness"
 )
 
 func TestEffectiveBudget_StageOverride(t *testing.T) {
@@ -86,5 +88,47 @@ func TestLoadConfigWithBudget(t *testing.T) {
 	}
 	if *s.MaxBudgetUsd != 7.5 {
 		t.Errorf("stage s1 MaxBudgetUsd = %v, want 7.5", *s.MaxBudgetUsd)
+	}
+}
+
+func TestLoadHarnessConfigWithNestedCodexSettings(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &Config{
+		Workflows:       map[string]Workflow{"full": {Stages: []string{"s1"}}},
+		Stages:          map[string]Stage{"s1": {Skill: "test"}},
+		DefaultWorkflow: "full",
+		Harnesses: map[string]harness.Config{
+			"codex": {
+				Binary:       "codex",
+				DefaultModel: "gpt-5.3-codex-spark",
+				Codex: harness.CodexConfig{
+					ModelContextWindow:         128000,
+					ContextHandoffThresholdPct: 50,
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	path := filepath.Join(dir, "orchestrator.json")
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	codex := loaded.HarnessConfig("codex").Codex
+	if codex.ModelContextWindow != 128000 {
+		t.Errorf("ModelContextWindow = %v, want 128000", codex.ModelContextWindow)
+	}
+	if codex.ContextHandoffThresholdPct != 50 {
+		t.Errorf("ContextHandoffThresholdPct = %v, want 50", codex.ContextHandoffThresholdPct)
 	}
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -83,6 +83,8 @@ func Validate(cfg *Config) *ValidationResult {
 		})
 	}
 
+	validateHarnessConfigs(result, cfg)
+
 	// Warn when a stage's effective harness is non-Claude but the stage still
 	// references Claude slash-command paths (.claude/). Those stages will fail at
 	// runtime because Codex (and other non-Claude harnesses) cannot execute
@@ -162,6 +164,44 @@ func Validate(cfg *Config) *ValidationResult {
 	}
 
 	return result
+}
+
+func validateHarnessConfigs(result *ValidationResult, cfg *Config) {
+	seen := map[string]harness.Config{}
+	for name, hcfg := range cfg.Backends {
+		seen[name] = hcfg
+	}
+	for name, hcfg := range cfg.Harnesses {
+		seen[name] = hcfg
+	}
+
+	for name, hcfg := range seen {
+		prefix := fmt.Sprintf("harnesses.%s.codex", name)
+		if hcfg.Codex.ModelContextWindow < 0 {
+			result.Errors = append(result.Errors, ValidationError{
+				Field:   prefix + ".model_context_window",
+				Message: "model_context_window must be non-negative",
+			})
+		}
+		if hcfg.Codex.ModelAutoCompactTokenLimit < 0 {
+			result.Errors = append(result.Errors, ValidationError{
+				Field:   prefix + ".model_auto_compact_token_limit",
+				Message: "model_auto_compact_token_limit must be non-negative",
+			})
+		}
+		if hcfg.Codex.ToolOutputTokenLimit < 0 {
+			result.Errors = append(result.Errors, ValidationError{
+				Field:   prefix + ".tool_output_token_limit",
+				Message: "tool_output_token_limit must be non-negative",
+			})
+		}
+		if hcfg.Codex.ContextHandoffThresholdPct < 0 || hcfg.Codex.ContextHandoffThresholdPct > 100 {
+			result.Errors = append(result.Errors, ValidationError{
+				Field:   prefix + ".context_handoff_threshold_percent",
+				Message: "context_handoff_threshold_percent must be between 0 and 100",
+			})
+		}
+	}
 }
 
 func validateAttempts(result *ValidationResult, cfg *Config, stageName, field string, attempts []ModelAttempt) {

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -3,6 +3,8 @@ package config
 import (
 	"testing"
 
+	"github.com/redblacktree/fastflow/internal/harness"
+
 	_ "github.com/redblacktree/fastflow/internal/harness/claude"
 )
 
@@ -57,5 +59,25 @@ func TestValidate_ZeroBudgetIsValid(t *testing.T) {
 	result := Validate(cfg)
 	if !result.IsValid() {
 		t.Errorf("expected zero budget to be valid, got errors: %s", result.Error())
+	}
+}
+
+func TestValidate_InvalidCodexHarnessConfig(t *testing.T) {
+	cfg := &Config{
+		Workflows:       map[string]Workflow{"full": {Stages: []string{"s1"}}},
+		Stages:          map[string]Stage{"s1": {Skill: "test"}},
+		DefaultWorkflow: "full",
+		Harnesses: map[string]harness.Config{
+			"codex": {
+				Codex: harness.CodexConfig{
+					ModelContextWindow:         -1,
+					ContextHandoffThresholdPct: 101,
+				},
+			},
+		},
+	}
+	result := Validate(cfg)
+	if result.IsValid() {
+		t.Error("expected validation error for invalid Codex harness config")
 	}
 }

--- a/internal/harness/codex/codex.go
+++ b/internal/harness/codex/codex.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strconv"
 
 	"github.com/redblacktree/fastflow/internal/harness"
 	"github.com/redblacktree/fastflow/internal/output"
@@ -16,6 +17,7 @@ import (
 type Harness struct {
 	binary       string
 	defaultModel string
+	config       harness.CodexConfig
 }
 
 // New creates a Codex harness from configuration.
@@ -28,7 +30,7 @@ func New(cfg harness.Config) *Harness {
 	if model == "" {
 		model = "o4-mini" // current Codex CLI default; see docs/backends.md
 	}
-	return &Harness{binary: bin, defaultModel: model}
+	return &Harness{binary: bin, defaultModel: model, config: cfg.Codex}
 }
 
 func (b *Harness) Name() string         { return "codex" }
@@ -83,8 +85,11 @@ func (b *Harness) Invoke(opts harness.InvokeOptions) (*harness.InvokeResult, err
 func (b *Harness) buildArgs(opts harness.InvokeOptions, lastMsgPath, prompt string) []string {
 	if opts.Continue {
 		// codex exec resume --last replaces "exec" and feeds a follow-up prompt
-		return []string{
+		args := []string{
 			"exec", "resume", "--last",
+		}
+		args = append(args, b.configArgs()...)
+		return append(args,
 			"--enable", "multi_agent",
 			"--model", opts.Model,
 			"--cd", opts.WorkDir,
@@ -92,10 +97,13 @@ func (b *Harness) buildArgs(opts harness.InvokeOptions, lastMsgPath, prompt stri
 			"--output-last-message", lastMsgPath,
 			"--full-auto",
 			prompt,
-		}
+		)
 	}
-	return []string{
+	args := []string{
 		"exec",
+	}
+	args = append(args, b.configArgs()...)
+	return append(args,
 		"--enable", "multi_agent",
 		"--model", opts.Model,
 		"--cd", opts.WorkDir,
@@ -103,7 +111,22 @@ func (b *Harness) buildArgs(opts harness.InvokeOptions, lastMsgPath, prompt stri
 		"--output-last-message", lastMsgPath,
 		"--full-auto",
 		prompt,
+	)
+}
+
+func (b *Harness) configArgs() []string {
+	var args []string
+	add := func(key string, value int) {
+		if value <= 0 {
+			return
+		}
+		args = append(args, "-c", key+"="+strconv.Itoa(value))
 	}
+
+	add("model_context_window", b.config.ModelContextWindow)
+	add("model_auto_compact_token_limit", b.config.ModelAutoCompactTokenLimit)
+	add("tool_output_token_limit", b.config.ToolOutputTokenLimit)
+	return args
 }
 
 // run executes the codex command, parses NDJSON events, reads the last message file.
@@ -120,16 +143,20 @@ func (b *Harness) run(cmd *exec.Cmd, opts harness.InvokeOptions, lastMsgPath str
 		return nil, fmt.Errorf("start %s: %w", b.binary, err)
 	}
 
-	sessionID, rawEvents := parseCodexStream(stdoutR, opts.Verbose, opts.Debug)
+	sessionID, rawEvents, usage := parseCodexStream(stdoutR, opts.Verbose, opts.Debug)
 
 	cmdErr := cmd.Wait()
 
 	rawOutput := rawEvents + "\n" + stderrBuf.String()
 
 	result := &harness.InvokeResult{
-		RawOutput: rawOutput,
-		SessionID: sessionID,
+		RawOutput:      rawOutput,
+		SessionID:      sessionID,
+		ContextTokens:  usage.InputTokens + usage.OutputTokens,
+		ContextWindow:  b.config.ModelContextWindow,
+		ContextPercent: b.contextPercent(usage),
 	}
+	result.HitContextHandoff = b.hitContextHandoffThreshold(result.ContextPercent)
 
 	if cmdErr != nil {
 		if exitErr, ok := cmdErr.(*exec.ExitError); ok {
@@ -165,4 +192,19 @@ func (b *Harness) run(cmd *exec.Cmd, opts harness.InvokeOptions, lastMsgPath str
 	}
 
 	return result, nil
+}
+
+func (b *Harness) contextPercent(usage codexUsage) float64 {
+	if b.config.ModelContextWindow <= 0 {
+		return 0
+	}
+	tokens := usage.InputTokens + usage.OutputTokens
+	if tokens <= 0 {
+		return 0
+	}
+	return float64(tokens) * 100 / float64(b.config.ModelContextWindow)
+}
+
+func (b *Harness) hitContextHandoffThreshold(percent float64) bool {
+	return b.config.ContextHandoffThresholdPct > 0 && percent >= b.config.ContextHandoffThresholdPct
 }

--- a/internal/harness/codex/codex_test.go
+++ b/internal/harness/codex/codex_test.go
@@ -38,7 +38,7 @@ func TestStripFrontmatter_UnclosedFrontmatter(t *testing.T) {
 
 func TestResolveSkill_CodexTakesPriority(t *testing.T) {
 	dir := t.TempDir()
-	codexPath := filepath.Join(dir, ".codex", "commands", "foo.md")
+	codexPath := filepath.Join(dir, ".codex", "skills", "foo", "SKILL.md")
 	os.MkdirAll(filepath.Dir(codexPath), 0755)
 	os.WriteFile(codexPath, []byte("codex skill body"), 0644)
 
@@ -133,7 +133,7 @@ func TestParseCodexStream_CollectsSessionID(t *testing.T) {
 	ndjson := `{"type":"session_started","session_id":"sess-abc123"}` + "\n" +
 		`{"type":"assistant_message","content":"Hello"}` + "\n"
 
-	sessionID, _ := parseCodexStream(strings.NewReader(ndjson), false, false)
+	sessionID, _, _ := parseCodexStream(strings.NewReader(ndjson), false, false)
 	if sessionID != "sess-abc123" {
 		t.Errorf("sessionID = %q, want sess-abc123", sessionID)
 	}
@@ -143,7 +143,7 @@ func TestParseCodexStream_IgnoresUnknownEventTypes(t *testing.T) {
 	ndjson := `{"type":"unknown_future_event","data":{"foo":"bar"}}` + "\n" +
 		`{"type":"session_started","session_id":"sess-xyz"}` + "\n"
 
-	sessionID, raw := parseCodexStream(strings.NewReader(ndjson), false, false)
+	sessionID, raw, _ := parseCodexStream(strings.NewReader(ndjson), false, false)
 	if sessionID != "sess-xyz" {
 		t.Errorf("sessionID = %q, want sess-xyz", sessionID)
 	}
@@ -157,7 +157,7 @@ func TestParseCodexStream_HandlesInvalidJSON(t *testing.T) {
 		`{"type":"session_started","session_id":"ok"}` + "\n"
 
 	// Should not panic; should still collect the valid session_id line
-	sessionID, _ := parseCodexStream(strings.NewReader(ndjson), false, false)
+	sessionID, _, _ := parseCodexStream(strings.NewReader(ndjson), false, false)
 	if sessionID != "ok" {
 		t.Errorf("sessionID = %q, want ok", sessionID)
 	}
@@ -167,9 +167,18 @@ func TestParseCodexStream_VerboseToolActivity(t *testing.T) {
 	ndjson := `{"type":"function_call","name":"write_file","arguments":{"path":"main.go","content":"package main"}}` + "\n"
 
 	// Verbose=true should not panic; we just verify it runs without error
-	_, raw := parseCodexStream(strings.NewReader(ndjson), true, false)
+	_, raw, _ := parseCodexStream(strings.NewReader(ndjson), true, false)
 	if !strings.Contains(raw, "function_call") {
 		t.Error("raw output should contain function_call event")
+	}
+}
+
+func TestParseCodexStream_CapturesTurnUsage(t *testing.T) {
+	ndjson := `{"type":"turn.completed","usage":{"input_tokens":100,"cached_input_tokens":20,"output_tokens":30,"reasoning_output_tokens":10}}` + "\n"
+
+	_, _, usage := parseCodexStream(strings.NewReader(ndjson), false, false)
+	if usage.InputTokens != 100 || usage.OutputTokens != 30 {
+		t.Fatalf("usage = %+v, want input=100 output=30", usage)
 	}
 }
 
@@ -230,6 +239,43 @@ func TestCodexHarness_BuildResumeArgsEnablesMultiAgent(t *testing.T) {
 
 	if !containsAdjacent(args, "--enable", "multi_agent") {
 		t.Fatalf("args = %v, want --enable multi_agent", args)
+	}
+}
+
+func TestCodexHarness_BuildArgsAddsConfiguredCompactionLimit(t *testing.T) {
+	b := New(harness.Config{
+		Codex: harness.CodexConfig{
+			ModelAutoCompactTokenLimit: 64000,
+			ToolOutputTokenLimit:       4000,
+		},
+	})
+	args := b.buildArgs(harness.InvokeOptions{
+		Model:   "gpt-5.3-codex-spark",
+		WorkDir: "/tmp/work",
+	}, "/tmp/last.txt", "do work")
+
+	if !containsAdjacent(args, "-c", "model_auto_compact_token_limit=64000") {
+		t.Fatalf("args = %v, want model_auto_compact_token_limit config", args)
+	}
+	if !containsAdjacent(args, "-c", "tool_output_token_limit=4000") {
+		t.Fatalf("args = %v, want tool_output_token_limit config", args)
+	}
+}
+
+func TestCodexHarness_ContextHandoffThreshold(t *testing.T) {
+	b := New(harness.Config{
+		Codex: harness.CodexConfig{
+			ModelContextWindow:         1000,
+			ContextHandoffThresholdPct: 50,
+		},
+	})
+
+	percent := b.contextPercent(codexUsage{InputTokens: 450, OutputTokens: 50})
+	if percent != 50 {
+		t.Fatalf("percent = %v, want 50", percent)
+	}
+	if !b.hitContextHandoffThreshold(percent) {
+		t.Fatal("expected context handoff threshold to be hit")
 	}
 }
 

--- a/internal/harness/codex/skill.go
+++ b/internal/harness/codex/skill.go
@@ -8,10 +8,11 @@ import (
 )
 
 // resolveSkill returns the body of a skill definition for inlining into a Codex prompt.
-// Looks up .codex/commands/<skill>.md first; falls back to .claude/commands/<skill>.md
-// (stripping frontmatter). Returns an error if neither exists.
+// Looks up native Codex skills/commands first, then falls back to Claude
+// command files (stripping frontmatter). Returns an error if none exists.
 func resolveSkill(workDir, skill string) (string, error) {
 	candidates := []string{
+		filepath.Join(workDir, ".codex", "skills", skill, "SKILL.md"),
 		filepath.Join(workDir, ".codex", "commands", skill+".md"),
 		filepath.Join(workDir, ".claude", "commands", skill+".md"),
 	}
@@ -20,7 +21,7 @@ func resolveSkill(workDir, skill string) (string, error) {
 			return stripFrontmatter(string(data)), nil
 		}
 	}
-	return "", fmt.Errorf("skill %q not found in .codex/commands/ or .claude/commands/", skill)
+	return "", fmt.Errorf("skill %q not found in .codex/skills/, .codex/commands/, or .claude/commands/", skill)
 }
 
 func stripFrontmatter(s string) string {

--- a/internal/harness/codex/stream.go
+++ b/internal/harness/codex/stream.go
@@ -19,12 +19,20 @@ type codexEvent struct {
 	Name      string          `json:"name"`      // function_call tool name
 	Arguments json.RawMessage `json:"arguments"` // function_call args
 	Message   string          `json:"message"`   // error message
+	Usage     codexUsage      `json:"usage"`
+}
+
+type codexUsage struct {
+	InputTokens           int `json:"input_tokens"`
+	CachedInputTokens     int `json:"cached_input_tokens"`
+	OutputTokens          int `json:"output_tokens"`
+	ReasoningOutputTokens int `json:"reasoning_output_tokens"`
 }
 
 // parseCodexStream reads NDJSON events from r, printing tool activity when
 // verbose is true. Returns the collected session ID and the raw combined line
 // output for auth classification.
-func parseCodexStream(r io.Reader, verbose, debug bool) (sessionID string, rawOutput string) {
+func parseCodexStream(r io.Reader, verbose, debug bool) (sessionID string, rawOutput string, usage codexUsage) {
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
 
@@ -48,6 +56,9 @@ func parseCodexStream(r io.Reader, verbose, debug bool) (sessionID string, rawOu
 		if ev.SessionID != "" && sessionID == "" {
 			sessionID = ev.SessionID
 		}
+		if ev.Type == "turn.completed" {
+			usage = ev.Usage
+		}
 
 		if verbose && ev.Type == "function_call" && ev.Name != "" {
 			summary := summarizeCodexTool(ev.Name, ev.Arguments)
@@ -56,7 +67,7 @@ func parseCodexStream(r io.Reader, verbose, debug bool) (sessionID string, rawOu
 	}
 
 	rawOutput = strings.Join(lines, "\n")
-	return sessionID, rawOutput
+	return sessionID, rawOutput, usage
 }
 
 // summarizeCodexTool returns a short display summary of a Codex tool call.

--- a/internal/harness/harness.go
+++ b/internal/harness/harness.go
@@ -34,8 +34,14 @@ type InvokeResult struct {
 	Model        string // model that produced this result, set by the runner when applicable
 	HitMaxTurns  bool
 	HitBudgetCap bool
-	SessionID    string
-	TotalCostUsd float64 // 0 if harness doesn't report cost
+	// HitContextHandoff is set when a harness reports approximate context usage
+	// above its configured handoff threshold.
+	HitContextHandoff bool
+	SessionID         string
+	TotalCostUsd      float64 // 0 if harness doesn't report cost
+	ContextTokens     int     // approximate tokens currently consuming context
+	ContextWindow     int     // configured context window used for percentage math
+	ContextPercent    float64
 }
 
 // Capabilities advertises what a harness can and cannot do, so the runner

--- a/internal/harness/registry.go
+++ b/internal/harness/registry.go
@@ -9,6 +9,16 @@ import (
 type Config struct {
 	Binary       string `json:"binary,omitempty"`        // override binary path; empty = harness default
 	DefaultModel string `json:"default_model,omitempty"` // override DefaultModel(); empty = harness default
+
+	Codex CodexConfig `json:"codex,omitempty"`
+}
+
+// CodexConfig contains Codex CLI-specific configuration passthroughs.
+type CodexConfig struct {
+	ModelContextWindow         int     `json:"model_context_window,omitempty"`
+	ModelAutoCompactTokenLimit int     `json:"model_auto_compact_token_limit,omitempty"`
+	ContextHandoffThresholdPct float64 `json:"context_handoff_threshold_percent,omitempty"`
+	ToolOutputTokenLimit       int     `json:"tool_output_token_limit,omitempty"`
 }
 
 // Constructor builds a Harness from its config block.

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -649,6 +649,40 @@ func (r *Runner) executeStage(ctx *RunContext, stageName string, stage *config.S
 		os.Remove(handoffPath) //nolint:errcheck
 	}
 
+	// Handle Codex context threshold with automatic handoff/resume. Codex only
+	// reports usage at turn completion, so this is an approximate post-turn
+	// trigger rather than a mid-turn interrupt.
+	contextResumptions := 0
+	for result.HitContextHandoff && contextResumptions < r.MaxResumptions {
+		contextResumptions++
+		warning := color.New(color.FgYellow).SprintFunc()
+		output.Printf("    %s Context usage %.1f%% (%d/%d tokens), attempting handoff/resume (%d/%d)...\n",
+			warning("CONTEXT"), result.ContextPercent, result.ContextTokens, result.ContextWindow, contextResumptions, r.MaxResumptions)
+
+		handoffResult, handoffErr := r.runContextHandoffCycle(ctx, stageName, stage, model, activeHarness)
+		if handoffErr != nil {
+			if r.Debug {
+				output.Printf("[DEBUG] Context handoff/resume failed: %v\n", handoffErr)
+			}
+			break
+		}
+
+		result.Output += "\n\n--- [RESUMED AFTER CONTEXT HANDOFF] ---\n\n" + handoffResult.Output
+		result.HitContextHandoff = handoffResult.HitContextHandoff
+		result.HitBudgetCap = handoffResult.HitBudgetCap
+		result.HitMaxTurns = handoffResult.HitMaxTurns
+		result.ExitCode = handoffResult.ExitCode
+		result.ContextTokens = handoffResult.ContextTokens
+		result.ContextWindow = handoffResult.ContextWindow
+		result.ContextPercent = handoffResult.ContextPercent
+	}
+
+	if result.HitContextHandoff && contextResumptions >= r.MaxResumptions {
+		warning := color.New(color.FgYellow).SprintFunc()
+		output.Printf("    %s Max context resumptions (%d) reached, proceeding with partial result\n",
+			warning("WARN"), r.MaxResumptions)
+	}
+
 	return result, nil
 }
 
@@ -839,16 +873,9 @@ func shouldTryNextModel(err error) bool {
 	return false
 }
 
-// runHandoffCycle runs create_handoff followed by resume_handoff.
-// If the harness doesn't support slash-commands, it skips the cycle with a warning.
+// runHandoffCycle runs ff_create_handoff followed by ff_resume_handoff.
+// Harnesses translate skills to their native invocation form.
 func (r *Runner) runHandoffCycle(ctx *RunContext, stageName string, model string, b hs.Harness) (*InvokeResult, error) {
-	if !b.Capabilities().SupportsSlashCommands {
-		warning := color.New(color.FgYellow).SprintFunc()
-		output.Printf("    %s Harness %q does not support slash-command handoff; returning partial result\n",
-			warning("WARN"), b.Name())
-		return &InvokeResult{}, nil
-	}
-
 	handoffContext := fmt.Sprintf("Stage: %s\nTicket: %s\nGoal: %s\nRun directory: %s",
 		stageName, ctx.Ticket, ctx.Goal, ctx.RunDir)
 
@@ -857,7 +884,7 @@ func (r *Runner) runHandoffCycle(ctx *RunContext, stageName string, model string
 	}
 
 	_, createErr := b.Invoke(hs.InvokeOptions{
-		Skill:        "create_handoff",
+		Skill:        "ff_create_handoff",
 		SkillContext: handoffContext,
 		Model:        model,
 		WorkDir:      ctx.WorkDir,
@@ -872,7 +899,7 @@ func (r *Runner) runHandoffCycle(ctx *RunContext, stageName string, model string
 	}
 
 	resumeResult, resumeErr := b.Invoke(hs.InvokeOptions{
-		Skill:        "resume_handoff",
+		Skill:        "ff_resume_handoff",
 		SkillContext: handoffContext,
 		Model:        model,
 		WorkDir:      ctx.WorkDir,
@@ -883,6 +910,87 @@ func (r *Runner) runHandoffCycle(ctx *RunContext, stageName string, model string
 	}
 
 	return resumeResult, nil
+}
+
+// runContextHandoffCycle asks the active Codex session to create an
+// ff_create_handoff handoff before starting a fresh session from that handoff.
+func (r *Runner) runContextHandoffCycle(ctx *RunContext, stageName string, stage *config.Stage, model string, b hs.Harness) (*InvokeResult, error) {
+	if !b.Capabilities().SupportsResume {
+		return nil, fmt.Errorf("harness %q does not support session resume for context handoff", b.Name())
+	}
+
+	handoffPointerPath := filepath.Join(ctx.WorkDir, ".fastflow", "latest-handoff-path.txt")
+	if err := os.MkdirAll(filepath.Dir(handoffPointerPath), 0755); err != nil {
+		return nil, fmt.Errorf("failed to create .fastflow directory: %w", err)
+	}
+	os.Remove(handoffPointerPath) //nolint:errcheck
+
+	handoffContext := fmt.Sprintf(`Stage: %s
+Ticket: %s
+Goal: %s
+Run directory: %s
+
+The current session has crossed the configured context handoff threshold. Use the ff_create_handoff skill to create a handoff now, while the full session context is still available. After the handoff is created, write the exact handoff file path and nothing else to this file:
+
+%s`, stageName, ctx.Ticket, ctx.Goal, ctx.RunDir, handoffPointerPath)
+
+	createResult, createErr := b.Invoke(hs.InvokeOptions{
+		Continue:     true,
+		Skill:        "ff_create_handoff",
+		SkillContext: handoffContext,
+		Model:        model,
+		WorkDir:      ctx.WorkDir,
+		Debug:        r.Debug,
+	})
+	if createErr != nil {
+		return nil, fmt.Errorf("ff_create_handoff failed: %w", createErr)
+	}
+
+	handoffPath, err := readHandoffPath(handoffPointerPath, createResult.Output)
+	if err != nil {
+		return nil, err
+	}
+
+	originalPrompt, err := r.buildStagePrompt(ctx, stageName, stage)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build stage prompt: %w", err)
+	}
+
+	resumePrompt := fmt.Sprintf(`%s
+
+Original stage prompt:
+%s`, handoffPath, originalPrompt)
+
+	resumeOpts := hs.InvokeOptions{
+		Model:   model,
+		WorkDir: ctx.WorkDir,
+		Verbose: r.Verbose,
+		Debug:   r.Debug,
+	}
+	resumeOpts.Skill = "ff_resume_handoff"
+	resumeOpts.SkillContext = resumePrompt
+
+	resumeResult, err := b.Invoke(resumeOpts)
+	if err != nil {
+		return nil, fmt.Errorf("context handoff resume failed: %w", err)
+	}
+
+	return resumeResult, nil
+}
+
+func readHandoffPath(pointerPath, fallback string) (string, error) {
+	if data, err := os.ReadFile(pointerPath); err == nil {
+		if path := strings.TrimSpace(string(data)); path != "" {
+			return path, nil
+		}
+	}
+	for _, field := range strings.Fields(fallback) {
+		clean := strings.Trim(field, "`'\"()[]{}.,")
+		if strings.Contains(clean, "thoughts/shared/handoffs/") && strings.HasSuffix(clean, ".md") {
+			return clean, nil
+		}
+	}
+	return "", fmt.Errorf("ff_create_handoff did not report a handoff path")
 }
 
 // runBudgetHandoffCycle handles context handoff when budget is exhausted.

--- a/internal/templates/files/orchestrator.json
+++ b/internal/templates/files/orchestrator.json
@@ -5,7 +5,7 @@
   "defaults": {
     "maxBudgetUsd": 0,
     "_maxBudgetNote": "Codex stages do not support maxBudgetUsd; keep this at 0 unless a future harness supports budget handoff.",
-    "_modelFallbackNote": "Use backup for transient Codex execution failures and escalation for judge-failed retries. Primary and backup use Spark; escalation uses GPT-5.5.",
+    "_modelFallbackNote": "Use gpt-5.3-codex for research/plan/implement/debug to reduce context handoff churn. Use Spark for bounded validate/commit-style stages. Escalation uses GPT-5.5 after judge-failed retries.",
     "_modelFallbackExample": {
       "backup": [
         {
@@ -27,7 +27,8 @@
           ]
         }
       ]
-    }
+    },
+    "_codexContextNote": "Codex-specific context handoff settings live under harnesses.codex.codex. The default template asks fastflow to run ff_create_handoff, then ff_resume_handoff in a fresh session, after a completed Codex turn reports 50%+ approximate context usage."
   },
   "workflows": {
     "full": {
@@ -174,7 +175,7 @@
           ]
         }
       ],
-      "model": "gpt-5.3-codex-spark"
+      "model": "gpt-5.3-codex"
     },
     "debug": {
       "prompt_file": ".codex/stages/debug.md",
@@ -203,7 +204,7 @@
           ]
         }
       ],
-      "model": "gpt-5.3-codex-spark"
+      "model": "gpt-5.3-codex"
     },
     "plan": {
       "prompt_file": ".codex/stages/plan.md",
@@ -233,7 +234,7 @@
           ]
         }
       ],
-      "model": "gpt-5.3-codex-spark"
+      "model": "gpt-5.3-codex"
     },
     "implement": {
       "prompt_file": ".codex/stages/implement.md",
@@ -262,7 +263,7 @@
           ]
         }
       ],
-      "model": "gpt-5.3-codex-spark"
+      "model": "gpt-5.3-codex"
     },
     "validate": {
       "prompt_file": ".codex/stages/validate.md",
@@ -413,7 +414,7 @@
         ".codex/skills/ff_research_codebase/SKILL.md"
       ],
       "judge_prompt": "Return YES only if the research output identifies the relevant code paths, summarizes the current behavior, notes constraints or risks, and writes or updates the expected research artifact under thoughts/shared/research/. Return NO for vague summaries, missing file references, missing artifact evidence, or unanswered questions that block planning.",
-      "model": "gpt-5.3-codex-spark",
+      "model": "gpt-5.3-codex",
       "backup": [
         {
           "harness": "codex",
@@ -442,7 +443,7 @@
         ".codex/skills/ff_debug/SKILL.md"
       ],
       "judge_prompt": "Return YES only if the debug output names a credible root cause, cites supporting evidence from code/logs/tests, and proposes a concrete fix or next action. Return NO for speculation without evidence, missing reproduction details, or unresolved blockers without a clear handoff.",
-      "model": "gpt-5.3-codex-spark",
+      "model": "gpt-5.3-codex",
       "backup": [
         {
           "harness": "codex",
@@ -472,7 +473,7 @@
         ".codex/skills/ff_create_plan/SKILL.md"
       ],
       "judge_prompt": "Return YES only if the plan artifact under thoughts/shared/plans/ is complete, actionable, sequenced, and includes acceptance criteria, validation steps, risk notes, and any required branch/PR strategy. Return NO if the plan is vague, omits success criteria, ignores known constraints, or leaves open questions that should have been resolved.",
-      "model": "gpt-5.3-codex-spark",
+      "model": "gpt-5.3-codex",
       "backup": [
         {
           "harness": "codex",
@@ -501,7 +502,7 @@
         ".codex/skills/ff_implement_plan/SKILL.md"
       ],
       "judge_prompt": "Return YES only if the output shows concrete code or config changes aligned with the plan/goal, explains meaningful decisions, and reports any validation attempted. Return NO if no relevant files changed, the work is only described but not done, errors are ignored, TODOs are left as substitutes for implementation, or validation failures are unresolved.",
-      "model": "gpt-5.3-codex-spark",
+      "model": "gpt-5.3-codex",
       "backup": [
         {
           "harness": "codex",
@@ -671,7 +672,11 @@
   "harnesses": {
     "codex": {
       "binary": "codex",
-      "default_model": "gpt-5.3-codex-spark"
+      "default_model": "gpt-5.3-codex-spark",
+      "codex": {
+        "model_context_window": 128000,
+        "context_handoff_threshold_percent": 50
+      }
     }
   }
 }

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -133,6 +133,9 @@ func TestTemplateContainsBudgetConfig(t *testing.T) {
 	if !strings.Contains(string(content), "_maxBudgetNote") {
 		t.Error("orchestrator.json template missing _maxBudgetNote")
 	}
+	if !strings.Contains(string(content), "context_handoff_threshold_percent") {
+		t.Error("orchestrator.json template missing Codex context compaction config")
+	}
 }
 
 func TestTemplateRequiresExist(t *testing.T) {

--- a/orchestrator.json
+++ b/orchestrator.json
@@ -95,7 +95,7 @@
           ]
         }
       ],
-      "model": "gpt-5.3-codex-spark"
+      "model": "gpt-5.3-codex"
     },
     "debug": {
       "prompt_file": ".codex/stages/debug.md",
@@ -124,7 +124,7 @@
           ]
         }
       ],
-      "model": "gpt-5.3-codex-spark"
+      "model": "gpt-5.3-codex"
     },
     "plan": {
       "prompt_file": ".codex/stages/plan.md",
@@ -154,7 +154,7 @@
           ]
         }
       ],
-      "model": "gpt-5.3-codex-spark"
+      "model": "gpt-5.3-codex"
     },
     "implement": {
       "prompt_file": ".codex/stages/implement.md",
@@ -183,7 +183,7 @@
           ]
         }
       ],
-      "model": "gpt-5.3-codex-spark"
+      "model": "gpt-5.3-codex"
     },
     "validate": {
       "prompt_file": ".codex/stages/validate.md",
@@ -329,7 +329,7 @@
     }
   },
   "defaults": {
-    "_modelFallbackNote": "Use backup for transient Codex execution failures and escalation for judge-failed retries. Primary and backup use Spark; escalation uses GPT-5.5.",
+    "_modelFallbackNote": "Use gpt-5.3-codex for research/plan/implement/debug to reduce context handoff churn. Use Spark for bounded validate/commit-style stages. Escalation uses GPT-5.5 after judge-failed retries.",
     "_modelFallbackExample": {
       "backup": [
         {
@@ -352,14 +352,19 @@
         }
       ]
     },
-    "_maxBudgetNote": "Codex stages do not support maxBudgetUsd; keep this at 0 unless a future harness supports budget handoff."
+    "_maxBudgetNote": "Codex stages do not support maxBudgetUsd; keep this at 0 unless a future harness supports budget handoff.",
+    "_codexContextNote": "Codex-specific context handoff settings live under harnesses.codex.codex. This config asks fastflow to run ff_create_handoff, then ff_resume_handoff in a fresh session, after a completed Codex turn reports 50%+ approximate context usage."
   },
   "harness": "codex",
   "judge_harness": "codex",
   "harnesses": {
     "codex": {
       "binary": "codex",
-      "default_model": "gpt-5.3-codex-spark"
+      "default_model": "gpt-5.3-codex-spark",
+      "codex": {
+        "model_context_window": 128000,
+        "context_handoff_threshold_percent": 50
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add Codex context handoff behavior that triggers on completed-turn usage at 50%+ of the configured context window and resumes through `ff_create_handoff` / `ff_resume_handoff`
- Move Codex-specific settings under `harnesses.codex.codex` so they are not treated as global harness defaults
- Update stage defaults so research/plan/implement/debug use `gpt-5.3-codex`, while validate/commit stay on Spark
- Refresh docs, validation, and templates to match the new Codex config shape

## Testing
- `go test ./...`
- `git diff --check`
- Added/updated unit coverage for Codex stream parsing, config validation, runner behavior, and template output