### PR TITLE
Repair stale fastflow runs

### DIFF
--- a/cmd/fastflow/main.go
+++ b/cmd/fastflow/main.go
@@ -3,6 +3,9 @@ package main
 
 import (
 	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -12,6 +15,7 @@ import (
 	"runtime/debug"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/redblacktree/fastflow/internal/config"
@@ -159,6 +163,28 @@ Examples:
 	RunE: runList,
 }
 
+var repairStaleRunsCmd = &cobra.Command{
+	Use:   "repair-stale-runs",
+	Short: "Mark abandoned running runs as stale",
+	Long: `Scan fastflow run state for entries that still say "running" even though
+their recorded process is gone, then mark those runs as stale.
+
+This is intended for operational repair and for OpenClaw ingestion. With
+--jsonl-facts, each stale run is emitted as an external fact compatible with
+agent-orchestrator ingest facts.
+
+Examples:
+  # Repair stale runs in the current repo/worktrees
+  fastflow repair-stale-runs
+
+  # Preview only REL-* repairs
+  fastflow repair-stale-runs --prefix REL- --dry-run
+
+  # Emit facts for OpenClaw ingestion
+  fastflow repair-stale-runs --jsonl-facts`,
+	RunE: runRepairStaleRuns,
+}
+
 var monitorCmd = &cobra.Command{
 	Use:   "monitor",
 	Short: "Start a web dashboard for monitoring fastflow runs",
@@ -223,6 +249,9 @@ var (
 	flagBlockedWorkspacePrefix  []string
 	flagAllowUntrustedWorkspace bool
 	flagMonitorAddr             string
+	flagRepairStalePrefix       string
+	flagRepairStaleDryRun       bool
+	flagRepairStaleJSONLFacts   bool
 )
 
 func init() {
@@ -283,11 +312,17 @@ func init() {
 	// Monitor command flags
 	monitorCmd.Flags().StringVar(&flagMonitorAddr, "addr", ":8080", "Address to listen on")
 
+	// Stale run repair flags
+	repairStaleRunsCmd.Flags().StringVar(&flagRepairStalePrefix, "prefix", "", "Filter tickets by prefix (e.g., FAS-, ENG-, REL-)")
+	repairStaleRunsCmd.Flags().BoolVar(&flagRepairStaleDryRun, "dry-run", false, "Preview repairs without changing state.json or pid files")
+	repairStaleRunsCmd.Flags().BoolVar(&flagRepairStaleJSONLFacts, "jsonl-facts", false, "Emit agent-orchestrator external facts as JSONL")
+
 	// Add commands
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(validateCmd)
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(listCmd)
+	rootCmd.AddCommand(repairStaleRunsCmd)
 	rootCmd.AddCommand(cleanCmd)
 	rootCmd.AddCommand(monitorCmd)
 }
@@ -1046,6 +1081,129 @@ func runList(cmd *cobra.Command, args []string) error {
 
 	output.Printf("\n%d run(s) found\n", len(entries))
 	return nil
+}
+
+type staleRunExternalFact struct {
+	ID             string         `json:"id"`
+	Source         string         `json:"source"`
+	ExternalID     string         `json:"external_id"`
+	WorkItemID     string         `json:"work_item_id,omitempty"`
+	FactType       string         `json:"fact_type"`
+	ObservedAt     time.Time      `json:"observed_at"`
+	ReceivedAt     time.Time      `json:"received_at"`
+	Payload        map[string]any `json:"payload,omitempty"`
+	IdempotencyKey string         `json:"idempotency_key,omitempty"`
+}
+
+func runRepairStaleRuns(cmd *cobra.Command, args []string) error {
+	warning := color.New(color.FgYellow).SprintFunc()
+	success := color.New(color.FgGreen).SprintFunc()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get working directory: %w", err)
+	}
+
+	repairs, err := monitor.RepairStaleRuns(cwd, flagRepairStalePrefix, flagRepairStaleDryRun)
+	if err != nil {
+		return fmt.Errorf("failed to repair stale runs: %w", err)
+	}
+
+	if flagRepairStaleJSONLFacts {
+		for _, repair := range repairs {
+			line, err := json.Marshal(staleRunFact(repair))
+			if err != nil {
+				return fmt.Errorf("failed to marshal stale run fact: %w", err)
+			}
+			output.Printf("%s\n", line)
+		}
+		return nil
+	}
+
+	if len(repairs) == 0 {
+		if flagRepairStalePrefix != "" {
+			output.Printf("No stale runs found matching prefix: %s\n", flagRepairStalePrefix)
+		} else {
+			output.Printf("No stale runs found.\n")
+		}
+		return nil
+	}
+
+	verb := success("Marked")
+	if flagRepairStaleDryRun {
+		verb = warning("Would mark")
+	}
+	for _, repair := range repairs {
+		pid := ""
+		if repair.Pid > 0 {
+			pid = fmt.Sprintf(" pid=%d", repair.Pid)
+		}
+		output.Printf("%s %s as stale: stage=%s%s reason=%s\n",
+			verb, repair.Ticket, stringOrFallback(repair.Stage, "(none)"), pid, repair.Reason)
+		output.Printf("  Run: %s\n", repair.RunDir)
+	}
+	output.Printf("\n%d stale run(s) %s\n", len(repairs), staleRepairSummaryVerb(flagRepairStaleDryRun))
+	return nil
+}
+
+func staleRepairSummaryVerb(dryRun bool) string {
+	if dryRun {
+		return "would be repaired"
+	}
+	return "repaired"
+}
+
+func staleRunFact(repair monitor.StaleRunRepair) staleRunExternalFact {
+	observedAt, err := time.Parse(time.RFC3339, repair.RepairedAt)
+	if err != nil {
+		observedAt = time.Now().UTC()
+	}
+	idempotencyKey := staleRunFactKey(repair)
+	hash := sha256.Sum256([]byte(idempotencyKey))
+	return staleRunExternalFact{
+		ID:             "fact-fastflow-" + hex.EncodeToString(hash[:])[:16],
+		Source:         "fastflow",
+		ExternalID:     fmt.Sprintf("%s:%s", repair.Ticket, repair.RunDir),
+		WorkItemID:     repair.Ticket,
+		FactType:       "fastflow_run_failed",
+		ObservedAt:     observedAt,
+		ReceivedAt:     time.Now().UTC(),
+		IdempotencyKey: idempotencyKey,
+		Payload: map[string]any{
+			"ticket":           repair.Ticket,
+			"workflow":         repair.Workflow,
+			"stage":            repair.Stage,
+			"work_dir":         repair.WorkDir,
+			"run_dir":          repair.RunDir,
+			"status_before":    repair.StatusBefore,
+			"status_after":     repair.StatusAfter,
+			"state_updated_at": repair.StateUpdatedAt,
+			"pid":              repair.Pid,
+			"pid_source":       repair.PIDSource,
+			"reason":           repair.Reason,
+			"dry_run":          repair.DryRun,
+			"changed":          repair.Changed,
+		},
+	}
+}
+
+func staleRunFactKey(repair monitor.StaleRunRepair) string {
+	return strings.Join([]string{
+		"fastflow",
+		repair.Ticket,
+		repair.RunDir,
+		repair.StatusBefore,
+		repair.StatusAfter,
+		fmt.Sprintf("%d", repair.Pid),
+		repair.StateUpdatedAt,
+	}, ":")
+}
+
+func stringOrFallback(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
 }
 
 func runClean(cmd *cobra.Command, args []string) error {

--- a/internal/monitor/discovery.go
+++ b/internal/monitor/discovery.go
@@ -72,15 +72,12 @@ func DiscoverRuns(cwd, prefix string) ([]RunEntry, error) {
 					if st.WorkDir != "" {
 						workDir = st.WorkDir
 					}
-					// Detect stale runs: status is running but process is dead
 					if status == state.StatusRunning {
-						pid, _ := state.ReadPID(runDir)
-						if pid > 0 {
-							if !state.IsProcessAlive(pid) {
-								status = "stale"
-							} else {
-								entryPid = pid
-							}
+						liveness := state.AssessRunLiveness(runDir, st)
+						if liveness.Stale {
+							status = state.StatusStale
+						} else if liveness.Running {
+							entryPid = liveness.Pid
 						}
 					}
 				}
@@ -119,16 +116,13 @@ func DiscoverRuns(cwd, prefix string) ([]RunEntry, error) {
 		if status == "" {
 			status = "unknown"
 		}
-		// Detect stale runs: status is running but process is dead
 		var entryPid int
 		if status == state.StatusRunning {
-			pid, _ := state.ReadPID(run.RunDir)
-			if pid > 0 {
-				if !state.IsProcessAlive(pid) {
-					status = "stale"
-				} else {
-					entryPid = pid
-				}
+			liveness := state.AssessRunLiveness(run.RunDir, run.State)
+			if liveness.Stale {
+				status = state.StatusStale
+			} else if liveness.Running {
+				entryPid = liveness.Pid
 			}
 		}
 		stage := run.State.Stage

--- a/internal/monitor/discovery_test.go
+++ b/internal/monitor/discovery_test.go
@@ -67,6 +67,7 @@ func TestDiscoverRuns_SingleRun(t *testing.T) {
 	st.Status = state.StatusRunning
 	st.Stage = "plan"
 	writeState(t, runDir, st)
+	writePID(t, runDir, os.Getpid())
 
 	entries, err := DiscoverRuns(root, "")
 	if err != nil {
@@ -81,6 +82,9 @@ func TestDiscoverRuns_SingleRun(t *testing.T) {
 	}
 	if e.Status != state.StatusRunning {
 		t.Errorf("status: got %q, want %q", e.Status, state.StatusRunning)
+	}
+	if e.Pid != os.Getpid() {
+		t.Errorf("pid: got %d, want %d", e.Pid, os.Getpid())
 	}
 	if e.Stage != "plan" {
 		t.Errorf("stage: got %q, want %q", e.Stage, "plan")
@@ -107,6 +111,9 @@ func TestDiscoverRuns_MultipleRuns(t *testing.T) {
 		st := state.NewState("default", []string{"implement"}, tc.ticket, root)
 		st.Status = tc.status
 		writeState(t, runDir, st)
+		if tc.status == state.StatusRunning {
+			writePID(t, runDir, os.Getpid())
+		}
 	}
 
 	entries, err := DiscoverRuns(root, "")
@@ -153,11 +160,30 @@ func TestDiscoverRuns_StaleDetection(t *testing.T) {
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 entry, got %d", len(entries))
 	}
-	if entries[0].Status != "stale" {
-		t.Errorf("status: got %q, want %q", entries[0].Status, "stale")
+	if entries[0].Status != state.StatusStale {
+		t.Errorf("status: got %q, want %q", entries[0].Status, state.StatusStale)
 	}
 	if entries[0].Pid != 0 {
 		t.Errorf("pid should be 0 for stale run, got %d", entries[0].Pid)
+	}
+}
+
+func TestDiscoverRuns_RunningWithoutPidIsStale(t *testing.T) {
+	root := t.TempDir()
+	runDir := makeRunDir(t, root, "ENG-NOPID")
+	st := state.NewState("default", []string{"implement"}, "ENG-NOPID", root)
+	st.Status = state.StatusRunning
+	writeState(t, runDir, st)
+
+	entries, err := DiscoverRuns(root, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Status != state.StatusStale {
+		t.Errorf("status: got %q, want %q", entries[0].Status, state.StatusStale)
 	}
 }
 

--- a/internal/monitor/repair.go
+++ b/internal/monitor/repair.go
@@ -1,0 +1,144 @@
+package monitor
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/redblacktree/fastflow/internal/runner"
+	"github.com/redblacktree/fastflow/internal/state"
+	"github.com/redblacktree/fastflow/internal/worktree"
+)
+
+// StaleRunRepair is the persisted result of detecting a dead process behind a
+// state.json file that still claimed to be running.
+type StaleRunRepair struct {
+	Ticket         string `json:"ticket"`
+	Workflow       string `json:"workflow,omitempty"`
+	Stage          string `json:"stage,omitempty"`
+	WorkDir        string `json:"work_dir,omitempty"`
+	RunDir         string `json:"run_dir"`
+	StatusBefore   string `json:"status_before"`
+	StatusAfter    string `json:"status_after"`
+	StateUpdatedAt string `json:"state_updated_at,omitempty"`
+	Pid            int    `json:"pid,omitempty"`
+	PIDSource      string `json:"pid_source,omitempty"`
+	Reason         string `json:"reason"`
+	RepairedAt     string `json:"repaired_at"`
+	DryRun         bool   `json:"dry_run,omitempty"`
+	Changed        bool   `json:"changed"`
+}
+
+type runCandidate struct {
+	ticket  string
+	workDir string
+	runDir  string
+}
+
+// RepairStaleRuns marks running runs with no live process as stale. It scans
+// both worktree-backed runs and no-worktree runs under the current repo.
+func RepairStaleRuns(cwd, prefix string, dryRun bool) ([]StaleRunRepair, error) {
+	candidates := collectRunCandidates(cwd, prefix)
+	repairs := []StaleRunRepair{}
+	for _, candidate := range candidates {
+		st, err := state.Load(candidate.runDir)
+		if err != nil {
+			return nil, fmt.Errorf("load %s: %w", candidate.runDir, err)
+		}
+		if st == nil {
+			continue
+		}
+		liveness := state.AssessRunLiveness(candidate.runDir, st)
+		if !liveness.Stale {
+			continue
+		}
+
+		now := time.Now().UTC()
+		ticket := candidate.ticket
+		if ticket == "" {
+			ticket = st.Ticket
+		}
+		reason := "process exited without finalizing state: " + liveness.Reason
+		repair := StaleRunRepair{
+			Ticket:         ticket,
+			Workflow:       st.Workflow,
+			Stage:          st.Stage,
+			WorkDir:        firstNonEmpty(st.WorkDir, candidate.workDir),
+			RunDir:         candidate.runDir,
+			StatusBefore:   st.Status,
+			StatusAfter:    state.StatusStale,
+			StateUpdatedAt: st.UpdatedAt,
+			Pid:            liveness.Pid,
+			PIDSource:      liveness.PIDSource,
+			Reason:         reason,
+			RepairedAt:     now.Format(time.RFC3339),
+			DryRun:         dryRun,
+		}
+		if !dryRun {
+			if err := st.SetFinalStatus(candidate.runDir, state.StatusStale, 1, reason); err != nil {
+				return nil, fmt.Errorf("mark %s stale: %w", candidate.runDir, err)
+			}
+			state.RemovePID(candidate.runDir)
+			repair.Changed = true
+		}
+		repairs = append(repairs, repair)
+	}
+	return repairs, nil
+}
+
+func collectRunCandidates(cwd, prefix string) []runCandidate {
+	seen := map[string]bool{}
+	candidates := []runCandidate{}
+
+	add := func(candidate runCandidate) {
+		if candidate.runDir == "" || seen[candidate.runDir] {
+			return
+		}
+		if prefix != "" && !strings.HasPrefix(candidate.ticket, prefix) {
+			return
+		}
+		seen[candidate.runDir] = true
+		candidates = append(candidates, candidate)
+	}
+
+	if mgr, err := worktree.NewManager(cwd); err == nil {
+		if worktrees, err := mgr.List(); err == nil {
+			for _, wt := range worktrees {
+				add(runCandidate{
+					ticket:  wt.Ticket,
+					workDir: wt.Path,
+					runDir:  runner.GetRunDir(wt.Path, wt.Ticket),
+				})
+			}
+		}
+	}
+
+	if runs, err := state.ScanRunDirs(cwd); err == nil {
+		for _, run := range runs {
+			workDir := cwd
+			if run.State != nil && run.State.WorkDir != "" {
+				workDir = run.State.WorkDir
+			}
+			add(runCandidate{ticket: run.Ticket, workDir: workDir, runDir: run.RunDir})
+		}
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].ticket == candidates[j].ticket {
+			return filepath.Clean(candidates[i].runDir) < filepath.Clean(candidates[j].runDir)
+		}
+		return candidates[i].ticket < candidates[j].ticket
+	})
+	return candidates
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/monitor/repair_test.go
+++ b/internal/monitor/repair_test.go
@@ -1,0 +1,114 @@
+package monitor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/redblacktree/fastflow/internal/state"
+)
+
+func TestRepairStaleRuns_MarksStateStaleAndRemovesPID(t *testing.T) {
+	root := t.TempDir()
+	runDir := makeRunDir(t, root, "REL-100")
+	st := state.NewState("default", []string{"implement"}, "REL-100", root)
+	st.Status = state.StatusRunning
+	st.Stage = "implement"
+	writeState(t, runDir, st)
+	writePID(t, runDir, 999999999)
+
+	repairs, err := RepairStaleRuns(root, "REL-", false)
+	if err != nil {
+		t.Fatalf("RepairStaleRuns failed: %v", err)
+	}
+	if len(repairs) != 1 {
+		t.Fatalf("expected 1 repair, got %d", len(repairs))
+	}
+	repair := repairs[0]
+	if !repair.Changed {
+		t.Fatal("expected repair to report Changed=true")
+	}
+	if repair.StatusBefore != state.StatusRunning || repair.StatusAfter != state.StatusStale {
+		t.Fatalf("unexpected status transition: %s -> %s", repair.StatusBefore, repair.StatusAfter)
+	}
+	if repair.Pid != 999999999 {
+		t.Fatalf("pid = %d, want 999999999", repair.Pid)
+	}
+	if !strings.Contains(repair.Reason, "pid 999999999 is not running") {
+		t.Fatalf("reason %q does not explain dead pid", repair.Reason)
+	}
+
+	loaded, err := state.Load(runDir)
+	if err != nil {
+		t.Fatalf("load repaired state: %v", err)
+	}
+	if loaded.Status != state.StatusStale {
+		t.Fatalf("state status = %q, want %q", loaded.Status, state.StatusStale)
+	}
+	if loaded.ExitCode != 1 {
+		t.Fatalf("exit_code = %d, want 1", loaded.ExitCode)
+	}
+	if loaded.Error == "" {
+		t.Fatal("expected repaired state to record error")
+	}
+	if _, err := os.Stat(filepath.Join(runDir, state.PidFileName)); !os.IsNotExist(err) {
+		t.Fatal("expected stale pid file to be removed")
+	}
+}
+
+func TestRepairStaleRuns_DryRunDoesNotMutate(t *testing.T) {
+	root := t.TempDir()
+	runDir := makeRunDir(t, root, "REL-101")
+	st := state.NewState("default", []string{"validate"}, "REL-101", root)
+	st.Status = state.StatusRunning
+	st.Stage = "validate"
+	writeState(t, runDir, st)
+	writePID(t, runDir, 999999999)
+
+	repairs, err := RepairStaleRuns(root, "REL-", true)
+	if err != nil {
+		t.Fatalf("RepairStaleRuns failed: %v", err)
+	}
+	if len(repairs) != 1 {
+		t.Fatalf("expected 1 repair, got %d", len(repairs))
+	}
+	if !repairs[0].DryRun || repairs[0].Changed {
+		t.Fatalf("expected dry-run repair without mutation, got dry_run=%v changed=%v", repairs[0].DryRun, repairs[0].Changed)
+	}
+
+	loaded, err := state.Load(runDir)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if loaded.Status != state.StatusRunning {
+		t.Fatalf("state status = %q, want %q", loaded.Status, state.StatusRunning)
+	}
+	if _, err := os.Stat(filepath.Join(runDir, state.PidFileName)); err != nil {
+		t.Fatalf("expected pid file to remain, got %v", err)
+	}
+}
+
+func TestRepairStaleRuns_SkipsLiveAndPrefixMismatch(t *testing.T) {
+	root := t.TempDir()
+
+	liveDir := makeRunDir(t, root, "REL-LIVE")
+	live := state.NewState("default", []string{"implement"}, "REL-LIVE", root)
+	live.Status = state.StatusRunning
+	writeState(t, liveDir, live)
+	writePID(t, liveDir, os.Getpid())
+
+	otherDir := makeRunDir(t, root, "ENG-STALE")
+	other := state.NewState("default", []string{"implement"}, "ENG-STALE", root)
+	other.Status = state.StatusRunning
+	writeState(t, otherDir, other)
+	writePID(t, otherDir, 999999999)
+
+	repairs, err := RepairStaleRuns(root, "REL-", false)
+	if err != nil {
+		t.Fatalf("RepairStaleRuns failed: %v", err)
+	}
+	if len(repairs) != 0 {
+		t.Fatalf("expected no repairs, got %d", len(repairs))
+	}
+}

--- a/internal/state/liveness.go
+++ b/internal/state/liveness.go
@@ -1,0 +1,57 @@
+package state
+
+import "fmt"
+
+// RunLiveness describes whether a state file still has a live fastflow process.
+type RunLiveness struct {
+	Running   bool
+	Stale     bool
+	Pid       int
+	PIDSource string
+	Reason    string
+}
+
+// AssessRunLiveness checks whether a run marked as running still has a live
+// process. Non-running states are neither running nor stale.
+func AssessRunLiveness(runDir string, st *PipelineState) RunLiveness {
+	if st == nil || st.Status != StatusRunning {
+		return RunLiveness{}
+	}
+
+	pid, err := ReadPID(runDir)
+	if err != nil {
+		return RunLiveness{
+			Stale:     true,
+			PIDSource: "pid_file",
+			Reason:    fmt.Sprintf("pid file is unreadable: %v", err),
+		}
+	}
+	if pid > 0 {
+		if IsProcessAlive(pid) {
+			return RunLiveness{Running: true, Pid: pid, PIDSource: "pid_file"}
+		}
+		return RunLiveness{
+			Stale:     true,
+			Pid:       pid,
+			PIDSource: "pid_file",
+			Reason:    fmt.Sprintf("pid %d is not running", pid),
+		}
+	}
+
+	if st.Pid > 0 {
+		if IsProcessAlive(st.Pid) {
+			return RunLiveness{Running: true, Pid: st.Pid, PIDSource: "state"}
+		}
+		return RunLiveness{
+			Stale:     true,
+			Pid:       st.Pid,
+			PIDSource: "state",
+			Reason:    fmt.Sprintf("state pid %d is not running", st.Pid),
+		}
+	}
+
+	return RunLiveness{
+		Stale:  true,
+		Reason: "state is running but no pid is recorded",
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -19,6 +19,7 @@ const (
 	StatusCheckpoint = "checkpoint"
 	StatusComplete   = "complete"
 	StatusFailed     = "failed"
+	StatusStale      = "stale"
 )
 
 // PipelineState tracks the progress of a pipeline run.
@@ -31,7 +32,7 @@ type PipelineState struct {
 	ConfigHash string `json:"config_hash"`
 	// Ticket is the ticket identifier for this run.
 	Ticket string `json:"ticket,omitempty"`
-	// Status is the current run status: running, checkpoint, complete, failed.
+	// Status is the current run status: running, checkpoint, complete, failed, stale.
 	Status string `json:"status,omitempty"`
 	// Stage is the name of the currently executing stage.
 	Stage string `json:"stage,omitempty"`


### PR DESCRIPTION
## Summary
- Add shared run liveness detection for `running` states with dead/missing PID evidence.
- Add `fastflow repair-stale-runs` to mark abandoned runs as `stale`, remove dead PID files, and emit OpenClaw-compatible JSONL facts.
- Update monitor discovery/tests so stale runs are surfaced consistently.

## Test Plan
- `go test ./...`
- Smoke-tested `fastflow repair-stale-runs --jsonl-facts --prefix REL- --dry-run` against a temporary stale run fixture.