### PR TITLE
Fix Codex rate-limit classification

### DIFF
--- a/internal/harness/codex/codex.go
+++ b/internal/harness/codex/codex.go
@@ -178,9 +178,17 @@ func (b *Harness) run(cmd *exec.Cmd, opts harness.InvokeOptions, lastMsgPath str
 		output.Printf("[DEBUG] %s output length: %d chars\n", b.binary, len(result.Output))
 	}
 
-	// Classify auth errors
-	if authErr := classifyAuthError(rawOutput); authErr != nil {
+	// Classify auth errors from Codex CLI failure channels, not successful
+	// assistant/tool output. Review context often mentions prior "rate limit"
+	// blockers, and that should not poison a successful current run.
+	stderrOutput := stderrBuf.String()
+	if authErr := classifyAuthError(stderrOutput); authErr != nil {
 		return nil, authErr
+	}
+	if result.ExitCode != 0 && result.Output == "" {
+		if authErr := classifyAuthError(rawEvents); authErr != nil {
+			return nil, authErr
+		}
 	}
 
 	if result.ExitCode != 0 && result.Output == "" {

--- a/internal/harness/codex/codex_test.go
+++ b/internal/harness/codex/codex_test.go
@@ -2,6 +2,7 @@ package codex
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -276,6 +277,59 @@ func TestCodexHarness_ContextHandoffThreshold(t *testing.T) {
 	}
 	if !b.hitContextHandoffThreshold(percent) {
 		t.Fatal("expected context handoff threshold to be hit")
+	}
+}
+
+func TestCodexHarness_RunDoesNotClassifySuccessfulAssistantTextAsRateLimit(t *testing.T) {
+	lastMsgPath := filepath.Join(t.TempDir(), "last-message.txt")
+	cmd := exec.Command(os.Args[0], "-test.run=TestCodexHarnessHelperProcess", "--")
+	cmd.Env = append(os.Environ(),
+		"GO_WANT_CODEX_HELPER=1",
+		"CODEX_HELPER_MODE=success-rate-limit-text",
+		"CODEX_LAST_MESSAGE="+lastMsgPath,
+	)
+
+	result, err := New(harness.Config{}).run(cmd, harness.InvokeOptions{}, lastMsgPath)
+	if err != nil {
+		t.Fatalf("run returned error for successful assistant text: %v", err)
+	}
+	if !strings.Contains(result.Output, "prior harness: rate limit reached") {
+		t.Fatalf("output = %q, want assistant text", result.Output)
+	}
+}
+
+func TestCodexHarness_RunClassifiesStderrRateLimit(t *testing.T) {
+	lastMsgPath := filepath.Join(t.TempDir(), "last-message.txt")
+	cmd := exec.Command(os.Args[0], "-test.run=TestCodexHarnessHelperProcess", "--")
+	cmd.Env = append(os.Environ(),
+		"GO_WANT_CODEX_HELPER=1",
+		"CODEX_HELPER_MODE=stderr-rate-limit",
+		"CODEX_LAST_MESSAGE="+lastMsgPath,
+	)
+
+	_, err := New(harness.Config{}).run(cmd, harness.InvokeOptions{}, lastMsgPath)
+	if err != harness.ErrRateLimited {
+		t.Fatalf("run error = %v, want ErrRateLimited", err)
+	}
+}
+
+func TestCodexHarnessHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_CODEX_HELPER") != "1" {
+		return
+	}
+	switch os.Getenv("CODEX_HELPER_MODE") {
+	case "success-rate-limit-text":
+		if err := os.WriteFile(os.Getenv("CODEX_LAST_MESSAGE"), []byte("prior harness: rate limit reached; current run succeeded"), 0644); err != nil {
+			panic(err)
+		}
+		os.Stdout.WriteString(`{"type":"session_started","session_id":"sess-test"}` + "\n")
+		os.Stdout.WriteString(`{"type":"assistant_message","content":"prior harness: rate limit reached; current run succeeded"}` + "\n")
+		os.Exit(0)
+	case "stderr-rate-limit":
+		os.Stderr.WriteString("rate limit exceeded\n")
+		os.Exit(0)
+	default:
+		os.Exit(2)
 	}
 }
 


### PR DESCRIPTION
## Summary
- classify Codex auth/rate-limit failures from stderr or nonzero failure output instead of successful assistant/tool output
- add regression coverage for successful assistant text that mentions a prior rate-limit blocker
- keep stderr rate-limit detection intact

## Tests
- go test ./...

## Local rollout
- rebuilt /Users/moneypenny/.local/bin/fastflow as v0.4.26-openclaw.1
- updated Q's fastflow wrapper to resolve shell-default fastflow first, then /Users/moneypenny/.local/bin/fastflow, then the old Go-bin fallback