### PR TITLE
Configure Codex sandbox behavior

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -21,7 +21,8 @@ aliases for existing configs. New configs should use `harness`,
       "default_model": "gpt-5.3-codex-spark",
       "codex": {
         "model_context_window": 128000,
-        "context_handoff_threshold_percent": 50
+        "context_handoff_threshold_percent": 50,
+        "dangerously_bypass_approvals_and_sandbox": true
       }
     }
   },
@@ -55,6 +56,8 @@ aliases for existing configs. New configs should use `harness`,
 | `harnesses.codex.codex.context_handoff_threshold_percent` | unset | After a completed Codex turn reports usage at or above this percentage, FastFlow resumes the session to run `ff_create_handoff`, then starts a fresh session through `ff_resume_handoff`. |
 | `harnesses.codex.codex.model_auto_compact_token_limit` | Codex default | Optional direct passthrough to Codex CLI's auto-compaction token threshold; use only as a higher last-resort backstop if desired. |
 | `harnesses.codex.codex.tool_output_token_limit` | Codex default | Optional direct passthrough to Codex CLI's tool output token limit. |
+| `harnesses.codex.codex.sandbox` | Codex default | Optional Codex CLI sandbox mode passthrough. Valid values are `read-only`, `workspace-write`, and `danger-full-access`. |
+| `harnesses.codex.codex.dangerously_bypass_approvals_and_sandbox` | `false` | When true, FastFlow passes `--dangerously-bypass-approvals-and-sandbox` to Codex CLI instead of `--full-auto`, giving the nested Codex run local/no-sandbox behavior. Use only in trusted worktrees. |
 | `stages.<name>.harness` | global `harness` | Per-stage harness override. |
 | `stages.<name>.model` | harness default model | Primary model for a stage. |
 | `stages.<name>.backup` | none | Ordered attempts for transient harness/model failures such as rate limits, capacity, unavailable models, or 5xx errors. |

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -104,6 +104,7 @@ func TestLoadHarnessConfigWithNestedCodexSettings(t *testing.T) {
 				Codex: harness.CodexConfig{
 					ModelContextWindow:         128000,
 					ContextHandoffThresholdPct: 50,
+					BypassApprovalsAndSandbox:  true,
 				},
 			},
 		},
@@ -127,6 +128,9 @@ func TestLoadHarnessConfigWithNestedCodexSettings(t *testing.T) {
 	codex := loaded.HarnessConfig("codex").Codex
 	if codex.ModelContextWindow != 128000 {
 		t.Errorf("ModelContextWindow = %v, want 128000", codex.ModelContextWindow)
+	}
+	if !codex.BypassApprovalsAndSandbox {
+		t.Error("BypassApprovalsAndSandbox = false, want true")
 	}
 	if codex.ContextHandoffThresholdPct != 50 {
 		t.Errorf("ContextHandoffThresholdPct = %v, want 50", codex.ContextHandoffThresholdPct)

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -201,6 +201,16 @@ func validateHarnessConfigs(result *ValidationResult, cfg *Config) {
 				Message: "context_handoff_threshold_percent must be between 0 and 100",
 			})
 		}
+		if sandbox := strings.TrimSpace(hcfg.Codex.Sandbox); sandbox != "" {
+			switch sandbox {
+			case "read-only", "workspace-write", "danger-full-access":
+			default:
+				result.Errors = append(result.Errors, ValidationError{
+					Field:   prefix + ".sandbox",
+					Message: "sandbox must be one of read-only, workspace-write, or danger-full-access",
+				})
+			}
+		}
 	}
 }
 

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -72,6 +72,7 @@ func TestValidate_InvalidCodexHarnessConfig(t *testing.T) {
 				Codex: harness.CodexConfig{
 					ModelContextWindow:         -1,
 					ContextHandoffThresholdPct: 101,
+					Sandbox:                    "moon-base",
 				},
 			},
 		},

--- a/internal/harness/codex/codex.go
+++ b/internal/harness/codex/codex.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 
 	"github.com/redblacktree/fastflow/internal/harness"
 	"github.com/redblacktree/fastflow/internal/output"
@@ -89,29 +90,29 @@ func (b *Harness) buildArgs(opts harness.InvokeOptions, lastMsgPath, prompt stri
 			"exec", "resume", "--last",
 		}
 		args = append(args, b.configArgs()...)
-		return append(args,
+		args = append(args,
 			"--enable", "multi_agent",
 			"--model", opts.Model,
 			"--cd", opts.WorkDir,
 			"--json",
 			"--output-last-message", lastMsgPath,
-			"--full-auto",
-			prompt,
 		)
+		args = append(args, b.executionModeArgs()...)
+		return append(args, prompt)
 	}
 	args := []string{
 		"exec",
 	}
 	args = append(args, b.configArgs()...)
-	return append(args,
+	args = append(args,
 		"--enable", "multi_agent",
 		"--model", opts.Model,
 		"--cd", opts.WorkDir,
 		"--json",
 		"--output-last-message", lastMsgPath,
-		"--full-auto",
-		prompt,
 	)
+	args = append(args, b.executionModeArgs()...)
+	return append(args, prompt)
 }
 
 func (b *Harness) configArgs() []string {
@@ -126,6 +127,17 @@ func (b *Harness) configArgs() []string {
 	add("model_context_window", b.config.ModelContextWindow)
 	add("model_auto_compact_token_limit", b.config.ModelAutoCompactTokenLimit)
 	add("tool_output_token_limit", b.config.ToolOutputTokenLimit)
+	return args
+}
+
+func (b *Harness) executionModeArgs() []string {
+	if b.config.BypassApprovalsAndSandbox {
+		return []string{"--dangerously-bypass-approvals-and-sandbox"}
+	}
+	args := []string{"--full-auto"}
+	if sandbox := strings.TrimSpace(b.config.Sandbox); sandbox != "" {
+		args = append(args, "--sandbox", sandbox)
+	}
 	return args
 }
 

--- a/internal/harness/codex/codex_test.go
+++ b/internal/harness/codex/codex_test.go
@@ -263,6 +263,44 @@ func TestCodexHarness_BuildArgsAddsConfiguredCompactionLimit(t *testing.T) {
 	}
 }
 
+func TestCodexHarness_BuildArgsAddsBypassSandboxFlag(t *testing.T) {
+	b := New(harness.Config{
+		Codex: harness.CodexConfig{
+			BypassApprovalsAndSandbox: true,
+		},
+	})
+	args := b.buildArgs(harness.InvokeOptions{
+		Model:   "gpt-5.3-codex-spark",
+		WorkDir: "/tmp/work",
+	}, "/tmp/last.txt", "do work")
+
+	if !contains(args, "--dangerously-bypass-approvals-and-sandbox") {
+		t.Fatalf("args = %v, want bypass flag", args)
+	}
+	if contains(args, "--full-auto") {
+		t.Fatalf("args = %v, did not expect --full-auto when bypassing sandbox", args)
+	}
+}
+
+func TestCodexHarness_BuildArgsAddsSandboxFlag(t *testing.T) {
+	b := New(harness.Config{
+		Codex: harness.CodexConfig{
+			Sandbox: "danger-full-access",
+		},
+	})
+	args := b.buildArgs(harness.InvokeOptions{
+		Model:   "gpt-5.3-codex-spark",
+		WorkDir: "/tmp/work",
+	}, "/tmp/last.txt", "do work")
+
+	if !containsAdjacent(args, "--sandbox", "danger-full-access") {
+		t.Fatalf("args = %v, want sandbox flag", args)
+	}
+	if !contains(args, "--full-auto") {
+		t.Fatalf("args = %v, want --full-auto with explicit sandbox", args)
+	}
+}
+
 func TestCodexHarness_ContextHandoffThreshold(t *testing.T) {
 	b := New(harness.Config{
 		Codex: harness.CodexConfig{
@@ -336,6 +374,15 @@ func TestCodexHarnessHelperProcess(t *testing.T) {
 func containsAdjacent(args []string, first, second string) bool {
 	for i := 0; i < len(args)-1; i++ {
 		if args[i] == first && args[i+1] == second {
+			return true
+		}
+	}
+	return false
+}
+
+func contains(args []string, value string) bool {
+	for _, arg := range args {
+		if arg == value {
 			return true
 		}
 	}

--- a/internal/harness/registry.go
+++ b/internal/harness/registry.go
@@ -19,6 +19,8 @@ type CodexConfig struct {
 	ModelAutoCompactTokenLimit int     `json:"model_auto_compact_token_limit,omitempty"`
 	ContextHandoffThresholdPct float64 `json:"context_handoff_threshold_percent,omitempty"`
 	ToolOutputTokenLimit       int     `json:"tool_output_token_limit,omitempty"`
+	Sandbox                    string  `json:"sandbox,omitempty"`
+	BypassApprovalsAndSandbox  bool    `json:"dangerously_bypass_approvals_and_sandbox,omitempty"`
 }
 
 // Constructor builds a Harness from its config block.

--- a/internal/templates/files/orchestrator.json
+++ b/internal/templates/files/orchestrator.json
@@ -675,7 +675,8 @@
       "default_model": "gpt-5.3-codex-spark",
       "codex": {
         "model_context_window": 128000,
-        "context_handoff_threshold_percent": 50
+        "context_handoff_threshold_percent": 50,
+        "dangerously_bypass_approvals_and_sandbox": true
       }
     }
   }

--- a/orchestrator.json
+++ b/orchestrator.json
@@ -675,7 +675,8 @@
       "default_model": "gpt-5.3-codex-spark",
       "codex": {
         "model_context_window": 128000,
-        "context_handoff_threshold_percent": 50
+        "context_handoff_threshold_percent": 50,
+        "dangerously_bypass_approvals_and_sandbox": true
       }
     }
   }


### PR DESCRIPTION
## Summary
- add Codex harness config for explicit sandbox mode and no-sandbox/local bypass
- default generated OpenClaw config to use Codex CLI local/no-sandbox mode
- document the new Codex backend fields and validate sandbox values

## Tests
- go test ./...
- jq empty orchestrator.json internal/templates/files/orchestrator.json
- git diff --check