### PR TITLE
Tighten Codex auth error classification

### DIFF
--- a/internal/harness/codex/auth.go
+++ b/internal/harness/codex/auth.go
@@ -15,12 +15,25 @@ func classifyAuthError(raw string) error {
 		strings.Contains(lower, "run `codex login`"),
 		strings.Contains(lower, "openai_api_key is not set"):
 		return harness.ErrNotLoggedIn
-	case strings.Contains(lower, "401"),
-		strings.Contains(lower, "invalid api key"),
+	case strings.Contains(lower, "invalid api key"),
 		strings.Contains(lower, "incorrect api key"):
 		return harness.ErrInvalidAPIKey
+	case strings.Contains(lower, "401 unauthorized"),
+		strings.Contains(lower, "unauthorized (401)"),
+		strings.Contains(lower, "http 401"),
+		strings.Contains(lower, "status 401"),
+		strings.Contains(lower, "status: 401"),
+		strings.Contains(lower, "status code 401"),
+		strings.Contains(lower, "status_code: 401"):
+		return harness.ErrInvalidAPIKey
 	case strings.Contains(lower, "rate limit"),
-		strings.Contains(lower, "429"):
+		strings.Contains(lower, "429 too many requests"),
+		strings.Contains(lower, "too many requests (429)"),
+		strings.Contains(lower, "http 429"),
+		strings.Contains(lower, "status 429"),
+		strings.Contains(lower, "status: 429"),
+		strings.Contains(lower, "status code 429"),
+		strings.Contains(lower, "status_code: 429"):
 		return harness.ErrRateLimited
 	}
 	return nil

--- a/internal/harness/codex/codex_test.go
+++ b/internal/harness/codex/codex_test.go
@@ -128,6 +128,18 @@ func TestClassifyAuthError_NoError(t *testing.T) {
 	}
 }
 
+func TestClassifyAuthError_IgnoresTimestampFragments(t *testing.T) {
+	cases := []string{
+		"2026-05-18T14:04:08.401211Z WARN codex_core_plugins::manifest: ignoring interface.defaultPrompt",
+		"2026-05-18T14:04:29.429211Z WARN codex_core_plugins::manifest: ignoring interface.defaultPrompt",
+	}
+	for _, c := range cases {
+		if err := classifyAuthError(c); err != nil {
+			t.Errorf("classifyAuthError(%q) = %v, want nil", c, err)
+		}
+	}
+}
+
 // ---------- parseCodexStream ----------
 
 func TestParseCodexStream_CollectsSessionID(t *testing.T) {


### PR DESCRIPTION
## Summary
- stop treating bare 401/429 substrings in Codex stderr as auth/rate-limit failures
- keep matching explicit auth/status messages like 401 Unauthorized and 429 Too Many Requests
- add regression coverage for Codex warning timestamps containing .401/.429 fragments

## Tests
- go test ./...
- git diff --check