### PR TITLE
Reset run state when resuming

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -132,12 +132,9 @@ func (r *Runner) Run(ctx *RunContext) error {
 		pipelineState = state.NewState(ctx.Workflow, workflow.Stages, ctx.Ticket, ctx.WorkDir)
 	}
 
-	// Store PID in state and save
-	pipelineState.Pid = os.Getpid()
-	if ctx.OnComplete != "" {
-		pipelineState.OnComplete = ctx.OnComplete
-	}
-	if err := pipelineState.Save(ctx.RunDir); err != nil {
+	// Store PID in state and save. Resume may reuse a previously failed state,
+	// so clear terminal fields before the new process begins work.
+	if err := pipelineState.StartRun(ctx.RunDir, os.Getpid(), ctx.OnComplete); err != nil {
 		return fmt.Errorf("failed to save initial state: %w", err)
 	}
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -107,6 +107,22 @@ func (s *PipelineState) SetStatus(runDir, status string) error {
 	return s.Save(runDir)
 }
 
+// StartRun marks an existing or new state as actively running under pid.
+func (s *PipelineState) StartRun(runDir string, pid int, onComplete string) error {
+	s.Status = StatusRunning
+	s.ExitCode = 0
+	s.Error = ""
+	s.Pid = pid
+	if onComplete != "" {
+		s.OnComplete = onComplete
+	}
+	s.UpdatedAt = time.Now().Format(time.RFC3339)
+	if s.StartedAt == "" {
+		s.StartedAt = s.UpdatedAt
+	}
+	return s.Save(runDir)
+}
+
 // SetStage updates the current stage name and saves.
 func (s *PipelineState) SetStage(runDir, stageName string) error {
 	s.Stage = stageName

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -56,6 +56,38 @@ func TestSetStatus(t *testing.T) {
 	}
 }
 
+func TestStartRunClearsPreviousFailure(t *testing.T) {
+	dir := t.TempDir()
+	s := NewState("full", []string{"research"}, "TEST-START", "/tmp/work")
+	if err := s.SetFinalStatus(dir, StatusFailed, 1, "received signal: terminated"); err != nil {
+		t.Fatalf("SetFinalStatus failed: %v", err)
+	}
+
+	if err := s.StartRun(dir, 12345, "notify-command"); err != nil {
+		t.Fatalf("StartRun failed: %v", err)
+	}
+
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if loaded.Status != StatusRunning {
+		t.Errorf("Status = %q, want %q", loaded.Status, StatusRunning)
+	}
+	if loaded.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0", loaded.ExitCode)
+	}
+	if loaded.Error != "" {
+		t.Errorf("Error = %q, want empty", loaded.Error)
+	}
+	if loaded.Pid != 12345 {
+		t.Errorf("Pid = %d, want 12345", loaded.Pid)
+	}
+	if loaded.OnComplete != "notify-command" {
+		t.Errorf("OnComplete = %q, want notify-command", loaded.OnComplete)
+	}
+}
+
 func TestSetStage(t *testing.T) {
 	dir := t.TempDir()
 	s := NewState("full", []string{"research", "plan"}, "TEST-003", "/tmp/work")


### PR DESCRIPTION
## Summary
- mark resumed runs as running before work starts
- clear stale terminal exit/error fields when reusing an existing state.json
- add regression coverage so prior failed states no longer remain failed while a new run is active

## Tests
- go test ./...
- git diff --check